### PR TITLE
Execute ts set to 0

### DIFF
--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -65,7 +65,7 @@ function createMainOrder(orderInfo: OrderInfoI) {
     leverage: orderInfo.leverage,
     reduceOnly: orderInfo.reduceOnly !== null ? orderInfo.reduceOnly : undefined,
     keepPositionLvg: orderInfo.keepPositionLeverage,
-    executionTimestamp: Math.floor(Date.now() / 1000),
+    executionTimestamp: 0,
     deadline: Math.floor(Date.now() / 1000 + 60 * 60 * deadlineMultiplier),
   };
 }
@@ -177,7 +177,7 @@ export const ActionBlock = memo(() => {
         leverage: orderInfo.leverage,
         reduceOnly: orderInfo.reduceOnly !== null ? orderInfo.reduceOnly : undefined,
         keepPositionLvg: orderInfo.keepPositionLeverage,
-        executionTimestamp: Math.floor(Date.now() / 1000),
+        executionTimestamp: 0,
       });
     }
 
@@ -195,7 +195,7 @@ export const ActionBlock = memo(() => {
         leverage: orderInfo.leverage,
         reduceOnly: orderInfo.reduceOnly !== null ? orderInfo.reduceOnly : undefined,
         keepPositionLvg: orderInfo.keepPositionLeverage,
-        executionTimestamp: Math.floor(Date.now() / 1000),
+        executionTimestamp: 0,
       });
     }
     return orders;
@@ -210,9 +210,6 @@ export const ActionBlock = memo(() => {
     orderDigest(chainId, parsedOrders, address)
       .then((data) => {
         if (data.data.digests.length > 0) {
-          signer.provider!.getBlock('latest').then((block) => {
-            data.data.SCOrders = data.data.SCOrders.map((order) => ({ ...order, executionTimestamp: block.timestamp }));
-          });
           approveMarginToken(signer, selectedPool.marginTokenAddr, proxyAddr, collateralDeposit).then((res) => {
             if (res?.hash) {
               console.log(res.hash);

--- a/src/components/positions-table/PositionsTable.tsx
+++ b/src/components/positions-table/PositionsTable.tsx
@@ -121,7 +121,7 @@ export const PositionsTable = memo(() => {
         side: selectedPosition.side === 'BUY' ? 'SELL' : 'BUY',
         type: OrderTypeE.Market.toUpperCase(),
         quantity: selectedPosition.positionNotionalBaseCCY,
-        executionTimestamp: Math.floor(Date.now() / 1000),
+        executionTimestamp: 0,
         reduceOnly: true,
         leverage: selectedPosition.leverage,
       };
@@ -129,12 +129,6 @@ export const PositionsTable = memo(() => {
       orderDigest(chainId, [closeOrder], address)
         .then((data) => {
           if (data.data.digests.length > 0) {
-            signer.provider!.getBlock('latest').then((block) => {
-              data.data.SCOrders = data.data.SCOrders.map((order) => ({
-                ...order,
-                executionTimestamp: block.timestamp,
-              }));
-            });
             approveMarginToken(signer, selectedPool.marginTokenAddr, proxyAddr, 0)
               .then((res) => {
                 if (res?.hash) {


### PR DESCRIPTION
On zk, block timestamps may lag behind "real" ts. Exec ts is not needed for the current FE order options