### PR TITLE
D8XL-137 Fix erroneous rebate volumes & rebate rate

### DIFF
--- a/src/components/header/elements/collaterals-select/CollateralsSelect.tsx
+++ b/src/components/header/elements/collaterals-select/CollateralsSelect.tsx
@@ -93,7 +93,7 @@ export const CollateralsSelect = memo(({ label, withNavigate }: CollateralsSelec
   const handleChange = (newItem: PoolI) => {
     let poolId: number | undefined = undefined;
     try {
-      poolId = traderAPI?.getPoolIdFromSymbol(pools[0].poolSymbol);
+      poolId = traderAPI?.getPoolIdFromSymbol(newItem.poolSymbol);
     } catch (error) {
       console.error(error);
     }

--- a/src/pages/refer-page/hooks.ts
+++ b/src/pages/refer-page/hooks.ts
@@ -18,7 +18,12 @@ export const useRebateRate = (chainId: number, address: string | undefined, refe
         referrerRole === ReferrerRoleE.NORMAL
           ? await getReferralRebate(chainId, address)
           : await getAgencyRebate(chainId);
-      return baseRebateResponse.data.percentageCut;
+
+      if (baseRebateResponse.type === 'error') {
+        return 0;
+      } else {
+        return baseRebateResponse.data.percentageCut;
+      }
     }
 
     return 0;


### PR DESCRIPTION
Fix referral volumes not being displayed.

Fix rebate rate now showing 0 if underlying API call fails with `type === 'error'`.

Resolves: [D8XL-137](https://github.com/D8-X/d8x-trader-frontend-lite/issues/137)