### PR TITLE
Fix display of referral codes created by agencies

### DIFF
--- a/src/components/referral-codes-table/elements/referral-codes-row/ReferralCodesRow.tsx
+++ b/src/components/referral-codes-table/elements/referral-codes-row/ReferralCodesRow.tsx
@@ -32,7 +32,7 @@ export const ReferralCodesRow = ({ isAgency, data }: ReferralCodesRowPropsI) => 
   const { address } = useAccount();
   const chainId = useChainId();
 
-  const baseRebate = useRebateRate(chainId, address, isAgency ? ReferrerRoleE.AGENCY : ReferrerRoleE.NORMAL);
+  const baseRebate = useRebateRate(chainId, address, data.agencyAddr ? ReferrerRoleE.AGENCY : ReferrerRoleE.NORMAL);
 
   const handleCodeShare = useCallback(
     (link: string, result: boolean) => {


### PR DESCRIPTION
Fix absolute percentages for referrers with agency codes. Rebates codes created by agencies always have the agency base rate