### PR TITLE
Fixes from mainnet testing

### DIFF
--- a/public/locales/cn/translations.json
+++ b/public/locales/cn/translations.json
@@ -1,7 +1,7 @@
 {
   "navigation": {
     "trade": "交易",
-    "refer": "邀请",
+    "refer": "邀请返佣",
     "vault": "金库",
     "portfolio": "投资组合"
   },
@@ -511,7 +511,7 @@
       }
     },
     "portfolio": {
-      "perpetuals": "万年历",
+      "perpetuals": "永续合约",
       "vault": "金库",
       "account-value": {
         "main-title": "你的帐户",
@@ -522,14 +522,14 @@
             "funds": "资金"
           },
           "perps": {
-            "title": "罪犯详情",
-            "leverage": "杠杆作用",
-            "unrealized": "未实现的 PnL",
-            "realized": "实现的 PnL",
+            "title": "永续合约详情",
+            "leverage": "杠杠",
+            "unrealized": "未实现盈亏",
+            "realized": "已实现盈亏",
             "referral": "推荐收入"
           },
           "vault": {
-            "title": "保险库详细信息",
+            "title": "金库详细信息",
             "assets": "资产",
             "assets-pool": "集合资产",
             "earnings-pool": "每池收益",

--- a/src/blockchain-api/contract-interactions/postOrder.ts
+++ b/src/blockchain-api/contract-interactions/postOrder.ts
@@ -28,7 +28,7 @@ export function postOrder(
       abi: LOB_ABI,
       functionName: 'postOrders',
       args: [orders, signatures],
-      gas: BigInt(2_000_000),
+      gas: BigInt(600_000 + (orders.length - 1) * 400_000),
       account: walletClient.account,
     })
     .then((tx) => ({ hash: tx }));

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -117,7 +117,7 @@ export const Header = memo(({ window }: HeaderPropsI) => {
   );
 
   useEffect(() => {
-    if (!requestRef.current && chainId) {
+    if (!requestRef.current && chainId && (!traderAPI || traderAPI.chainId === chainId)) {
       requestRef.current = true;
       setExchangeInfo(null);
       getExchangeInfo(chainId, traderAPI)

--- a/src/components/header/elements/settings-block/components/one-click-trading/components/OneClickTradingModal.tsx
+++ b/src/components/header/elements/settings-block/components/one-click-trading/components/OneClickTradingModal.tsx
@@ -19,7 +19,7 @@ import { ToastContent } from 'components/toast-content/ToastContent';
 import { getDelegateKey } from 'helpers/getDelegateKey';
 import { activatedOneClickTradingAtom, delegateAddressAtom, tradingClientAtom } from 'store/app.store';
 import { storageKeyAtom } from 'store/order-block.store';
-import { proxyAddrAtom } from 'store/pools.store';
+import { proxyAddrAtom, traderAPIAtom } from 'store/pools.store';
 
 import { FundingModal } from './FundingModal';
 import styles from '../OneClickTradingButton.module.scss';
@@ -39,6 +39,7 @@ export const OneClickTradingModal = ({ isOpen, onClose }: OneClickTradingModalPr
   const [delegateAddress, setDelegateAddress] = useAtom(delegateAddressAtom);
   const [proxyAddr] = useAtom(proxyAddrAtom);
   const [storageKey, setStorageKey] = useAtom(storageKeyAtom);
+  const [traderAPI] = useAtom(traderAPIAtom);
   const setTradingClient = useSetAtom(tradingClientAtom);
 
   const [isLoading, setLoading] = useState(false);
@@ -57,16 +58,16 @@ export const OneClickTradingModal = ({ isOpen, onClose }: OneClickTradingModalPr
   });
 
   useEffect(() => {
-    if (!proxyAddr || !address) {
+    if (!address || !traderAPI || traderAPI?.chainId !== publicClient.chain.id) {
       return;
     }
 
     setLoading(true);
 
-    hasDelegate(publicClient, proxyAddr as Address, address)
+    hasDelegate(publicClient, traderAPI.getProxyAddress() as Address, address)
       .then(setDelegated)
       .finally(() => setLoading(false));
-  }, [publicClient, proxyAddr, address]);
+  }, [publicClient, address, traderAPI]);
 
   useEffect(() => {
     if (!isDelegated || (address && address !== walletClient?.account?.address)) {

--- a/src/components/header/elements/settings-block/components/one-click-trading/components/OneClickTradingModal.tsx
+++ b/src/components/header/elements/settings-block/components/one-click-trading/components/OneClickTradingModal.tsx
@@ -161,16 +161,10 @@ export const OneClickTradingModal = ({ isOpen, onClose }: OneClickTradingModalPr
   });
 
   useEffect(() => {
-    if (activatedOneClickTrading && delegateAddress !== '' && !!delegateBalance && delegateBalance.value === 0n) {
+    if (activatedOneClickTrading && delegateAddress !== '' && !!delegateBalance && delegateBalance.value < 10n) {
       setFundingModalOpen(true);
     }
   }, [activatedOneClickTrading, delegateBalance, delegateAddress]);
-
-  useEffect(() => {
-    if (delegateAddress !== '' && delegateBalance && delegateBalance.value > 0n) {
-      setFundingModalOpen(false);
-    }
-  }, [delegateBalance, delegateAddress]);
 
   const handleRemove = () => {
     if (!walletClient || !proxyAddr || handleRemoveRef.current) {

--- a/src/components/open-orders-table/OpenOrdersTable.tsx
+++ b/src/components/open-orders-table/OpenOrdersTable.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useResizeDetector } from 'react-resize-detector';
 import { toast } from 'react-toastify';
 import { type Address, decodeEventLog, encodeEventTopics } from 'viem';
-import { useAccount, useChainId, useWaitForTransaction, useWalletClient } from 'wagmi';
+import { useAccount, useChainId, useNetwork, useWaitForTransaction, useWalletClient } from 'wagmi';
 
 import {
   Box,
@@ -43,6 +43,7 @@ import { OpenOrderRow } from './elements/OpenOrderRow';
 import { OpenOrderBlock } from './elements/open-order-block/OpenOrderBlock';
 
 import styles from './OpenOrdersTable.module.scss';
+import { getTxnLink } from 'helpers/getTxnLink';
 
 const MIN_WIDTH_FOR_TABLE = 788;
 const TOPIC_CANCEL_SUCCESS = encodeEventTopics({ abi: PROXY_ABI, eventName: 'PerpetualLimitOrderCancelled' })[0];
@@ -53,6 +54,7 @@ export const OpenOrdersTable = memo(() => {
 
   const { address, isDisconnected, isConnected } = useAccount();
   const chainId = useChainId();
+  const { chain } = useNetwork();
   const { data: walletClient } = useWalletClient({ chainId: chainId });
   const { width, ref } = useResizeDetector();
 
@@ -131,6 +133,19 @@ export const OpenOrdersTable = memo(() => {
                 label: t('pages.trade.orders-table.toasts.order-cancelled.body'),
                 value: traderAPI?.getSymbolFromPerpId((args as { perpetualId: number }).perpetualId),
               },
+              {
+                label: '',
+                value: (
+                  <a
+                    href={getTxnLink(chain?.blockExplorers?.default?.url, txHash)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={styles.shareLink}
+                  >
+                    {txHash}
+                  </a>
+                ),
+              },
             ]}
           />
         );
@@ -192,7 +207,6 @@ export const OpenOrdersTable = memo(() => {
               setCancelModalOpen(false);
               setSelectedOrder(null);
               setRequestSent(false);
-              console.log(`cancelOrder tx hash: ${tx.hash}`);
               toast.success(
                 <ToastContent title={t('pages.trade.orders-table.toasts.cancel-order.title')} bodyLines={[]} />
               );

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -2,7 +2,7 @@ import { useAtom, useSetAtom } from 'jotai';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
-import { type Address, useAccount, useChainId, useWaitForTransaction, useWalletClient } from 'wagmi';
+import { type Address, useAccount, useChainId, useWaitForTransaction, useWalletClient, useNetwork } from 'wagmi';
 
 import { Box, Button, CircularProgress, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
 
@@ -35,6 +35,7 @@ import { formatNumber } from 'utils/formatNumber';
 import { formatToCurrency } from 'utils/formatToCurrency';
 
 import styles from './ActionBlock.module.scss';
+import { getTxnLink } from 'helpers/getTxnLink';
 
 function createMainOrder(orderInfo: OrderInfoI) {
   let orderType = orderInfo.orderType.toUpperCase();
@@ -95,6 +96,7 @@ export const ActionBlock = memo(() => {
 
   const { address } = useAccount();
   const chainId = useChainId();
+  const { chain } = useNetwork();
 
   const { data: walletClient } = useWalletClient({
     chainId: chainId,
@@ -243,6 +245,19 @@ export const ActionBlock = memo(() => {
               label: t('pages.trade.action-block.toasts.order-submitted.body'),
               value: orderInfo?.symbol,
             },
+            {
+              label: '',
+              value: (
+                <a
+                  href={getTxnLink(chain?.blockExplorers?.default?.url, txHash)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.shareLink}
+                >
+                  {txHash}
+                </a>
+              ),
+            },
           ]}
         />
       );
@@ -290,7 +305,6 @@ export const ActionBlock = memo(() => {
                 .then((tx) => {
                   setShowReviewOrderModal(false);
                   // success submitting order to the node
-                  // console.log(`postOrder tx hash: ${tx.hash}`);
                   // order was sent
                   clearInputsData();
                   toast.success(

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -290,7 +290,7 @@ export const ActionBlock = memo(() => {
                 .then((tx) => {
                   setShowReviewOrderModal(false);
                   // success submitting order to the node
-                  console.log(`postOrder tx hash: ${tx.hash}`);
+                  // console.log(`postOrder tx hash: ${tx.hash}`);
                   // order was sent
                   clearInputsData();
                   toast.success(

--- a/src/components/positions-table/elements/modals/close-modal/CloseModal.tsx
+++ b/src/components/positions-table/elements/modals/close-modal/CloseModal.tsx
@@ -117,7 +117,7 @@ export const CloseModal = memo(({ isOpen, selectedPosition, closeModal }: CloseM
               .then((tx) => {
                 setTxHash(tx.hash);
                 setSymbolForTx(selectedPosition.symbol);
-                console.log(`postOrder tx hash: ${tx.hash}`);
+                // console.log(`postOrder tx hash: ${tx.hash}`);
                 toast.success(
                   <ToastContent title={t('pages.trade.positions-table.toasts.submit-close.title')} bodyLines={[]} />
                 );

--- a/src/components/positions-table/elements/modals/close-modal/CloseModal.tsx
+++ b/src/components/positions-table/elements/modals/close-modal/CloseModal.tsx
@@ -2,7 +2,7 @@ import { useAtom, useSetAtom } from 'jotai';
 import { memo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
-import { type Address, useAccount, useChainId, useWaitForTransaction, useWalletClient } from 'wagmi';
+import { type Address, useAccount, useChainId, useWaitForTransaction, useWalletClient, useNetwork } from 'wagmi';
 
 import { Box, Button, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
 
@@ -21,6 +21,7 @@ import { OrderSideE, OrderTypeE } from 'types/enums';
 import { type MarginAccountI, type OrderI } from 'types/types';
 
 import styles from '../Modal.module.scss';
+import { getTxnLink } from 'helpers/getTxnLink';
 
 interface CloseModalPropsI {
   isOpen: boolean;
@@ -38,6 +39,7 @@ export const CloseModal = memo(({ isOpen, selectedPosition, closeModal }: CloseM
   const [tradingClient] = useAtom(tradingClientAtom);
 
   const chainId = useChainId();
+  const { chain } = useNetwork();
   const { address } = useAccount();
   const { data: walletClient } = useWalletClient({ chainId: chainId });
 
@@ -57,6 +59,19 @@ export const CloseModal = memo(({ isOpen, selectedPosition, closeModal }: CloseM
             {
               label: t('pages.trade.positions-table.toasts.submitted.body'),
               value: symbolForTx,
+            },
+            {
+              label: '',
+              value: (
+                <a
+                  href={getTxnLink(chain?.blockExplorers?.default?.url, txHash)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.shareLink}
+                >
+                  {txHash}
+                </a>
+              ),
             },
           ]}
         />
@@ -117,7 +132,6 @@ export const CloseModal = memo(({ isOpen, selectedPosition, closeModal }: CloseM
               .then((tx) => {
                 setTxHash(tx.hash);
                 setSymbolForTx(selectedPosition.symbol);
-                // console.log(`postOrder tx hash: ${tx.hash}`);
                 toast.success(
                   <ToastContent title={t('pages.trade.positions-table.toasts.submit-close.title')} bodyLines={[]} />
                 );

--- a/src/components/positions-table/elements/modals/modify-modal/ModifyModal.tsx
+++ b/src/components/positions-table/elements/modals/modify-modal/ModifyModal.tsx
@@ -339,7 +339,7 @@ export const ModifyModal = memo(({ isOpen, selectedPosition, closeModal }: Modif
           ).then(() => {
             deposit(tradingClient, address, data)
               .then((tx) => {
-                console.log(`deposit tx hash: ${tx.hash}`);
+                // console.log(`deposit tx hash: ${tx.hash}`);
                 setTxHashForAdd(tx.hash);
                 setAmountForAdd(addCollateral);
                 setSymbolForTx(selectedPosition.symbol);
@@ -384,7 +384,7 @@ export const ModifyModal = memo(({ isOpen, selectedPosition, closeModal }: Modif
         .then(({ data }) => {
           withdraw(tradingClient, address, data)
             .then((tx) => {
-              console.log(`withdraw tx hash: ${tx.hash}`);
+              // console.log(`withdraw tx hash: ${tx.hash}`);
               setTxHashForRemove(tx.hash);
               setAmountForRemove(removeCollateral);
               setSymbolForTx(selectedPosition.symbol);

--- a/src/components/positions-table/elements/modals/modify-modal/ModifyModal.tsx
+++ b/src/components/positions-table/elements/modals/modify-modal/ModifyModal.tsx
@@ -2,7 +2,7 @@ import { useAtom } from 'jotai';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
-import { type Address, useAccount, useChainId, useWaitForTransaction, useWalletClient } from 'wagmi';
+import { type Address, useAccount, useChainId, useWaitForTransaction, useWalletClient, useNetwork } from 'wagmi';
 
 import {
   Box,
@@ -47,6 +47,7 @@ import { ModifyTypeE, ModifyTypeSelector } from '../../modify-type-selector/Modi
 
 import styles from '../Modal.module.scss';
 import { tradingClientAtom } from 'store/app.store';
+import { getTxnLink } from 'helpers/getTxnLink';
 
 interface ModifyModalPropsI {
   isOpen: boolean;
@@ -65,6 +66,7 @@ export const ModifyModal = memo(({ isOpen, selectedPosition, closeModal }: Modif
   const [tradingClient] = useAtom(tradingClientAtom);
 
   const chainId = useChainId();
+  const { chain } = useNetwork();
   const { address } = useAccount();
   const { data: walletClient } = useWalletClient({ chainId: chainId });
 
@@ -97,6 +99,19 @@ export const ModifyModal = memo(({ isOpen, selectedPosition, closeModal }: Modif
             {
               label: t('pages.trade.positions-table.toasts.collateral-added.body2'),
               value: formatNumber(amountForAdd),
+            },
+            {
+              label: '',
+              value: (
+                <a
+                  href={getTxnLink(chain?.blockExplorers?.default?.url, txHashForAdd)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.shareLink}
+                >
+                  {txHashForAdd}
+                </a>
+              ),
             },
           ]}
         />
@@ -132,6 +147,19 @@ export const ModifyModal = memo(({ isOpen, selectedPosition, closeModal }: Modif
             {
               label: t('pages.trade.positions-table.toasts.collateral-removed.body2'),
               value: formatNumber(amountForRemove),
+            },
+            {
+              label: '',
+              value: (
+                <a
+                  href={getTxnLink(chain?.blockExplorers?.default?.url, txHashForRemove)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.shareLink}
+                >
+                  {txHashForRemove}
+                </a>
+              ),
             },
           ]}
         />
@@ -339,7 +367,6 @@ export const ModifyModal = memo(({ isOpen, selectedPosition, closeModal }: Modif
           ).then(() => {
             deposit(tradingClient, address, data)
               .then((tx) => {
-                // console.log(`deposit tx hash: ${tx.hash}`);
                 setTxHashForAdd(tx.hash);
                 setAmountForAdd(addCollateral);
                 setSymbolForTx(selectedPosition.symbol);
@@ -384,7 +411,6 @@ export const ModifyModal = memo(({ isOpen, selectedPosition, closeModal }: Modif
         .then(({ data }) => {
           withdraw(tradingClient, address, data)
             .then((tx) => {
-              // console.log(`withdraw tx hash: ${tx.hash}`);
               setTxHashForRemove(tx.hash);
               setAmountForRemove(removeCollateral);
               setSymbolForTx(selectedPosition.symbol);

--- a/src/components/positions-table/elements/modals/modify-tp-sl-modal/ModifyTpSlModal.tsx
+++ b/src/components/positions-table/elements/modals/modify-tp-sl-modal/ModifyTpSlModal.tsx
@@ -189,7 +189,7 @@ export const ModifyTpSlModal = memo(({ isOpen, selectedPosition, closeModal }: M
               if (data.data.digest) {
                 cancelOrder(tradingClient, HashZero, data.data, orderToCancel.id)
                   .then((tx) => {
-                    console.log(`cancelOrder tx hash: ${tx.hash}`);
+                    // console.log(`cancelOrder tx hash: ${tx.hash}`);
                     toast.success(
                       <ToastContent title={t('pages.trade.orders-table.toasts.cancel-order.title')} bodyLines={[]} />
                     );
@@ -263,7 +263,7 @@ export const ModifyTpSlModal = memo(({ isOpen, selectedPosition, closeModal }: M
                 postOrder(tradingClient, signatures, data.data, false)
                   .then((tx) => {
                     // success submitting order to the node
-                    console.log(`postOrder tx hash: ${tx.hash}`);
+                    // console.log(`postOrder tx hash: ${tx.hash}`);
                     // order was sent
                     setTakeProfitPrice(null);
                     setStopLossPrice(null);

--- a/src/components/positions-table/elements/modals/modify-tp-sl-modal/ModifyTpSlModal.tsx
+++ b/src/components/positions-table/elements/modals/modify-tp-sl-modal/ModifyTpSlModal.tsx
@@ -27,6 +27,7 @@ import { StopLossSelector } from './components/StopLossSelector';
 import { TakeProfitSelector } from './components/TakeProfitSelector';
 
 import styles from '../Modal.module.scss';
+import { getTxnLink } from 'helpers/getTxnLink';
 
 interface ModifyModalPropsI {
   isOpen: boolean;
@@ -133,6 +134,19 @@ export const ModifyTpSlModal = memo(({ isOpen, selectedPosition, closeModal }: M
               label: t('pages.trade.action-block.toasts.order-submitted.body'),
               value: selectedPosition?.symbol,
             },
+            {
+              label: '',
+              value: (
+                <a
+                  href={getTxnLink(chain?.blockExplorers?.default?.url, txHash)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.shareLink}
+                >
+                  {txHash}
+                </a>
+              ),
+            },
           ]}
         />
       );
@@ -189,9 +203,25 @@ export const ModifyTpSlModal = memo(({ isOpen, selectedPosition, closeModal }: M
               if (data.data.digest) {
                 cancelOrder(tradingClient, HashZero, data.data, orderToCancel.id)
                   .then((tx) => {
-                    // console.log(`cancelOrder tx hash: ${tx.hash}`);
                     toast.success(
-                      <ToastContent title={t('pages.trade.orders-table.toasts.cancel-order.title')} bodyLines={[]} />
+                      <ToastContent
+                        title={t('pages.trade.orders-table.toasts.cancel-order.title')}
+                        bodyLines={[
+                          {
+                            label: '',
+                            value: (
+                              <a
+                                href={getTxnLink(chain?.blockExplorers?.default?.url, tx.hash)}
+                                target="_blank"
+                                rel="noreferrer"
+                                className={styles.shareLink}
+                              >
+                                {tx.hash}
+                              </a>
+                            ),
+                          },
+                        ]}
+                      />
                     );
                   })
                   .catch((error) => {
@@ -263,7 +293,6 @@ export const ModifyTpSlModal = memo(({ isOpen, selectedPosition, closeModal }: M
                 postOrder(tradingClient, signatures, data.data, false)
                   .then((tx) => {
                     // success submitting order to the node
-                    // console.log(`postOrder tx hash: ${tx.hash}`);
                     // order was sent
                     setTakeProfitPrice(null);
                     setStopLossPrice(null);

--- a/src/components/wallet-connect-button/WalletConnectButton.tsx
+++ b/src/components/wallet-connect-button/WalletConnectButton.tsx
@@ -56,7 +56,7 @@ export const WalletConnectButton = memo(({ buttonClassName }: WalletConnectButto
       setTraderAPI(null);
       setSDKConnected(false);
       setAPIBusy(true);
-      console.log(`loading SDK on chainId ${_chainId}`);
+      // console.log(`loading SDK on chainId ${_chainId}`);
       const configSDK = PerpetualDataHandler.readSDKConfig(_chainId);
       if (config.priceFeedEndpoint[_chainId] && config.priceFeedEndpoint[_chainId] !== '') {
         const pythPriceServiceIdx = configSDK.priceFeedEndpoints?.findIndex(({ type }) => type === 'pyth');
@@ -75,7 +75,7 @@ export const WalletConnectButton = memo(({ buttonClassName }: WalletConnectButto
           loadingAPIRef.current = false;
           setAPIBusy(false);
           setSDKConnected(true);
-          console.log(`SDK loaded on chain id ${_chainId}`);
+          // console.log(`SDK loaded on chain id ${_chainId}`);
           setTraderAPI(newTraderAPI);
         })
         .catch((err) => {

--- a/src/helpers/getTxnLink.ts
+++ b/src/helpers/getTxnLink.ts
@@ -1,0 +1,6 @@
+export function getTxnLink(baseURL: string | undefined, hash: string | undefined) {
+  if (!hash || !baseURL) {
+    return '';
+  }
+  return baseURL + '/tx/' + hash;
+}

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -32,7 +32,7 @@ export async function getExchangeInfo(
   chainId: number,
   traderAPI: TraderInterface | null
 ): Promise<ValidatedResponseI<ExchangeInfoI>> {
-  if (traderAPI) {
+  if (traderAPI && traderAPI.chainId === chainId) {
     // console.log('exchangeInfo via SDK');
     const info = await traderAPI.exchangeInfo();
     return { type: 'exchange-info', msg: '', data: info };
@@ -47,7 +47,7 @@ export async function getPerpetualStaticInfo(
   traderAPI: TraderInterface | null,
   symbol: string
 ): Promise<ValidatedResponseI<PerpetualStaticInfoI>> {
-  if (traderAPI) {
+  if (traderAPI && traderAPI.chainId === chainId) {
     // console.log('perpStaticInfo via SDK');
     const info = traderAPI.getPerpetualStaticInfo(symbol);
     return { type: 'perpetual-static-info', msg: '', data: info };
@@ -75,12 +75,12 @@ export async function getPositionRisk(
     params.append('t', '' + timestamp);
   }
 
-  if (traderAPI) {
+  if (traderAPI && traderAPI.chainId === chainId) {
     console.log(`positionRisk via SDK`);
     const data = await traderAPI.positionRisk(traderAddr);
     return { type: 'position-risk', msg: '', data };
   } else {
-    // console.log(`positionRisk via BE`);
+    console.log(`positionRisk via BE`);
     return fetchUrl(`position-risk?${params}`, chainId);
   }
 }
@@ -117,7 +117,7 @@ export function positionRiskOnCollateralAction(
   amount: number,
   positionRisk: MarginAccountI
 ): Promise<ValidatedResponseI<{ newPositionRisk: MarginAccountI; availableMargin: number }>> {
-  if (traderAPI) {
+  if (traderAPI && traderAPI.chainId === chainId) {
     // console.log('positionRiskOnCollateral via SDK');
     return traderAPI.positionRiskOnCollateralAction(amount, positionRisk).then((data) => {
       return traderAPI.getAvailableMargin(traderAddr, positionRisk.symbol).then((margin) => {
@@ -154,7 +154,7 @@ export async function getOpenOrders(
   traderAddr: string,
   timestamp?: number
 ): Promise<ValidatedResponseI<PerpetualOpenOrdersI[]>> {
-  if (traderAPI) {
+  if (traderAPI && traderAPI.chainId === chainId) {
     console.log(`openOrders via SDK`);
     const data = await traderAPI.openOrders(traderAddr);
     return { type: 'open-orders', msg: '', data };
@@ -187,7 +187,7 @@ export function getMaxOrderSizeForTrader(
   symbol: string,
   timestamp?: number
 ): Promise<ValidatedResponseI<MaxOrderSizeResponseI>> {
-  if (traderAPI) {
+  if (traderAPI && traderAPI.chainId === chainId) {
     return traderAPI
       .maxOrderSizeForTrader(traderAddr, symbol)
       .then(({ buy, sell }) => {
@@ -242,7 +242,7 @@ export function getCancelOrder(
   symbol: string,
   orderId: string
 ): Promise<ValidatedResponseI<CancelOrderResponseI>> {
-  if (traderAPI) {
+  if (traderAPI && traderAPI.chainId === chainId) {
     const cancelABI = traderAPI.getOrderBookABI(symbol, 'cancelOrder');
     return traderAPI.cancelOrderDigest(symbol, orderId).then((digest) => {
       return traderAPI.fetchLatestFeedPriceInfo(symbol).then((submission) => {

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -76,11 +76,11 @@ export async function getPositionRisk(
   }
 
   if (traderAPI && traderAPI.chainId === chainId) {
-    console.log(`positionRisk via SDK`);
+    // console.log(`positionRisk via SDK`);
     const data = await traderAPI.positionRisk(traderAddr);
     return { type: 'position-risk', msg: '', data };
   } else {
-    console.log(`positionRisk via BE`);
+    // console.log(`positionRisk via BE`);
     return fetchUrl(`position-risk?${params}`, chainId);
   }
 }
@@ -99,7 +99,7 @@ export function positionRiskOnTrade(
     maxShortTrade: number;
   }>
 > {
-  console.log('positionRiskOnTrade via SDK');
+  // console.log('positionRiskOnTrade via SDK');
   return traderAPI.positionRiskOnTrade(traderAddr, order, curAccount).then((data) => {
     return { type: 'position-risk-on-trade', msg: '', data: data } as ValidatedResponseI<{
       newPositionRisk: MarginAccountI;
@@ -155,7 +155,7 @@ export async function getOpenOrders(
   timestamp?: number
 ): Promise<ValidatedResponseI<PerpetualOpenOrdersI[]>> {
   if (traderAPI && traderAPI.chainId === chainId) {
-    console.log(`openOrders via SDK`);
+    // console.log(`openOrders via SDK`);
     const data = await traderAPI.openOrders(traderAddr);
     return { type: 'open-orders', msg: '', data };
   } else {

--- a/src/pages/portfolio-page/store/fetchUnrealizedPnL.ts
+++ b/src/pages/portfolio-page/store/fetchUnrealizedPnL.ts
@@ -43,7 +43,7 @@ export const fetchUnrealizedPnLAtom = atom(null, async (get, set, userAddress: A
     }
   });
 
-  const leverage = totalPositionNotionalBaseCCY / totalCollateralCC || 0;
+  const leverage = totalPositionNotionalBaseCCY / (totalCollateralCC + totalUnrealizedPnl) || 0;
 
   set(leverageAtom, leverage);
   set(totalUnrealizedPnLAtom, totalUnrealizedPnl);

--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Add.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Add.tsx
@@ -107,7 +107,7 @@ export const Add = memo(() => {
     approveMarginToken(walletClient, selectedPool.marginTokenAddr, proxyAddr, addAmount, poolTokenDecimals)
       .then(() => {
         addLiquidity(walletClient, liqProvTool, selectedPool.poolSymbol, addAmount).then((tx) => {
-          console.log(`addLiquidity tx hash: ${tx.hash}`);
+          // console.log(`addLiquidity tx hash: ${tx.hash}`);
           setTxHash(tx.hash);
           toast.success(<ToastContent title={t('pages.vault.toast.adding')} bodyLines={[]} />);
         });

--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Add.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Add.tsx
@@ -2,7 +2,7 @@ import { useAtom, useSetAtom } from 'jotai';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
-import { type Address, useAccount, useWaitForTransaction, useWalletClient } from 'wagmi';
+import { type Address, useAccount, useWaitForTransaction, useWalletClient, useNetwork } from 'wagmi';
 
 import { Box, Button, InputAdornment, Link, OutlinedInput, Typography } from '@mui/material';
 
@@ -23,10 +23,12 @@ import { dCurrencyPriceAtom, sdkConnectedAtom, triggerUserStatsUpdateAtom } from
 import { formatToCurrency } from 'utils/formatToCurrency';
 
 import styles from './Action.module.scss';
+import { getTxnLink } from 'helpers/getTxnLink';
 
 export const Add = memo(() => {
   const { t } = useTranslation();
   const { address } = useAccount();
+  const { chain } = useNetwork();
   const { data: walletClient } = useWalletClient({
     onError(error) {
       console.log(error);
@@ -72,7 +74,26 @@ export const Add = memo(() => {
   useWaitForTransaction({
     hash: txHash,
     onSuccess() {
-      toast.success(<ToastContent title={t('pages.vault.toast.added')} bodyLines={[]} />);
+      toast.success(
+        <ToastContent
+          title={t('pages.vault.toast.added')}
+          bodyLines={[
+            {
+              label: '',
+              value: (
+                <a
+                  href={getTxnLink(chain?.blockExplorers?.default?.url, txHash)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.shareLink}
+                >
+                  {txHash}
+                </a>
+              ),
+            },
+          ]}
+        />
+      );
     },
     onError(reason) {
       toast.error(
@@ -107,7 +128,6 @@ export const Add = memo(() => {
     approveMarginToken(walletClient, selectedPool.marginTokenAddr, proxyAddr, addAmount, poolTokenDecimals)
       .then(() => {
         addLiquidity(walletClient, liqProvTool, selectedPool.poolSymbol, addAmount).then((tx) => {
-          // console.log(`addLiquidity tx hash: ${tx.hash}`);
           setTxHash(tx.hash);
           toast.success(<ToastContent title={t('pages.vault.toast.adding')} bodyLines={[]} />);
         });

--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Initiate.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Initiate.tsx
@@ -94,7 +94,7 @@ export const Initiate = memo(() => {
 
     initiateLiquidityWithdrawal(walletClient, liqProvTool, selectedPool.poolSymbol, initiateAmount)
       .then((tx) => {
-        console.log(`initiateLiquidityWithdrawal tx hash: ${tx.hash}`);
+        // console.log(`initiateLiquidityWithdrawal tx hash: ${tx.hash}`);
         setTxHash(tx.hash);
         toast.success(<ToastContent title={t('pages.vault.toast.initiating')} bodyLines={[]} />);
       })

--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Initiate.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Initiate.tsx
@@ -12,6 +12,7 @@ import { ResponsiveInput } from 'components/responsive-input/ResponsiveInput';
 import { ToastContent } from 'components/toast-content/ToastContent';
 import { selectedPoolAtom, traderAPIAtom } from 'store/pools.store';
 import {
+  dCurrencyPriceAtom,
   triggerUserStatsUpdateAtom,
   triggerWithdrawalsUpdateAtom,
   userAmountAtom,
@@ -26,6 +27,7 @@ export const Initiate = memo(() => {
   const [liqProvTool] = useAtom(traderAPIAtom);
   const [userAmount] = useAtom(userAmountAtom);
   const [withdrawals] = useAtom(withdrawalsAtom);
+  const [dCurrencyPrice] = useAtom(dCurrencyPriceAtom);
   const setTriggerWithdrawalsUpdate = useSetAtom(triggerWithdrawalsUpdateAtom);
   const setTriggerUserStatsUpdate = useSetAtom(triggerUserStatsUpdateAtom);
 
@@ -125,13 +127,27 @@ export const Initiate = memo(() => {
     t,
   ]);
 
+  const minAmount = useMemo(() => {
+    if (selectedPool && dCurrencyPrice) {
+      return (0.5 * selectedPool.brokerCollateralLotSize) / dCurrencyPrice;
+    }
+  }, [selectedPool, dCurrencyPrice]);
+
   const isButtonDisabled = useMemo(() => {
-    if (!withdrawals || withdrawals.length > 0 || !userAmount || !initiateAmount || requestSent) {
+    if (
+      !withdrawals ||
+      withdrawals.length > 0 ||
+      !userAmount ||
+      !initiateAmount ||
+      requestSent ||
+      !minAmount ||
+      initiateAmount < minAmount
+    ) {
       return true;
     } else {
       return userAmount < initiateAmount;
     }
-  }, [withdrawals, userAmount, initiateAmount, requestSent]);
+  }, [withdrawals, userAmount, initiateAmount, requestSent, minAmount]);
 
   return (
     <>

--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Withdraw.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Withdraw.tsx
@@ -2,7 +2,7 @@ import { useAtom, useSetAtom } from 'jotai';
 import { memo, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
-import { type Address, useWaitForTransaction, useWalletClient } from 'wagmi';
+import { type Address, useWaitForTransaction, useWalletClient, useNetwork } from 'wagmi';
 
 import { Box, Button, Typography } from '@mui/material';
 
@@ -24,6 +24,7 @@ import { formatToCurrency } from 'utils/formatToCurrency';
 import { Initiate } from './Initiate';
 
 import styles from './Action.module.scss';
+import { getTxnLink } from 'helpers/getTxnLink';
 
 interface WithdrawPropsI {
   withdrawOn: string;
@@ -39,6 +40,7 @@ export const Withdraw = memo(({ withdrawOn }: WithdrawPropsI) => {
   const setTriggerWithdrawalsUpdate = useSetAtom(triggerWithdrawalsUpdateAtom);
   const setTriggerUserStatsUpdate = useSetAtom(triggerUserStatsUpdateAtom);
 
+  const { chain } = useNetwork();
   const { data: walletClient } = useWalletClient();
 
   const [requestSent, setRequestSent] = useState(false);
@@ -49,7 +51,26 @@ export const Withdraw = memo(({ withdrawOn }: WithdrawPropsI) => {
   useWaitForTransaction({
     hash: txHash,
     onSuccess() {
-      toast.success(<ToastContent title={t('pages.vault.toast.withdrawn')} bodyLines={[]} />);
+      toast.success(
+        <ToastContent
+          title={t('pages.vault.toast.withdrawn')}
+          bodyLines={[
+            {
+              label: '',
+              value: (
+                <a
+                  href={getTxnLink(chain?.blockExplorers?.default?.url, txHash)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.shareLink}
+                >
+                  {txHash}
+                </a>
+              ),
+            },
+          ]}
+        />
+      );
     },
     onError(reason) {
       toast.error(
@@ -80,7 +101,6 @@ export const Withdraw = memo(({ withdrawOn }: WithdrawPropsI) => {
 
     executeLiquidityWithdrawal(walletClient, liqProvTool, selectedPool.poolSymbol)
       .then((tx) => {
-        // console.log(`executeLiquidityWithdrawal tx hash: ${tx.hash}`);
         setTxHash(tx.hash);
         toast.success(<ToastContent title={t('pages.vault.toast.withdrawing')} bodyLines={[]} />);
       })

--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Withdraw.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Withdraw.tsx
@@ -80,7 +80,7 @@ export const Withdraw = memo(({ withdrawOn }: WithdrawPropsI) => {
 
     executeLiquidityWithdrawal(walletClient, liqProvTool, selectedPool.poolSymbol)
       .then((tx) => {
-        console.log(`executeLiquidityWithdrawal tx hash: ${tx.hash}`);
+        // console.log(`executeLiquidityWithdrawal tx hash: ${tx.hash}`);
         setTxHash(tx.hash);
         toast.success(<ToastContent title={t('pages.vault.toast.withdrawing')} bodyLines={[]} />);
       })


### PR DESCRIPTION
- [x] tighter gas estimate for posting orders (users see a lower estimated fee in metamask)
- [x] for calls that can be made via sdk or backend, check chain id before using the sdk
- [x] leverage calculation in portfolio page now consistent with trade page
- [x] don't call isDelegate until sdk has loaded and therefore the proxy address is correct
- [x] don't call exchange-info via sdk if sdk has the wrong chain-id
- [x] close fund delegate popup after wallet interaction
- [x] enforce floor on amount entered during withdrawal initiation
- [x] remove debugging logs (tx hashes, etc) 
- [x] link to block explorer in most success toasts 