### PR TITLE
refetch balance instead of using atom

### DIFF
--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Add.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Add.tsx
@@ -40,7 +40,7 @@ export const Add = memo(() => {
   const { data: poolTokenBalanceResult } = useBalance({
     address,
     token: selectedPool?.marginTokenAddr as Address,
-    enabled: !!selectedPool?.marginTokenAddr,
+    enabled: !!selectedPool?.marginTokenAddr && !!address,
   });
 
   const poolTokenBalance = useMemo(() => {

--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Add.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Add.tsx
@@ -2,7 +2,7 @@ import { useAtom, useSetAtom } from 'jotai';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
-import { type Address, useAccount, useWaitForTransaction, useWalletClient, useNetwork } from 'wagmi';
+import { type Address, useAccount, useWaitForTransaction, useWalletClient, useNetwork, useBalance } from 'wagmi';
 
 import { Box, Button, InputAdornment, Link, OutlinedInput, Typography } from '@mui/material';
 
@@ -12,13 +12,7 @@ import { addLiquidity } from 'blockchain-api/contract-interactions/addLiquidity'
 import { InfoLabelBlock } from 'components/info-label-block/InfoLabelBlock';
 import { ResponsiveInput } from 'components/responsive-input/ResponsiveInput';
 import { ToastContent } from 'components/toast-content/ToastContent';
-import {
-  poolTokenBalanceAtom,
-  poolTokenDecimalsAtom,
-  proxyAddrAtom,
-  selectedPoolAtom,
-  traderAPIAtom,
-} from 'store/pools.store';
+import { poolTokenDecimalsAtom, proxyAddrAtom, selectedPoolAtom, traderAPIAtom } from 'store/pools.store';
 import { dCurrencyPriceAtom, sdkConnectedAtom, triggerUserStatsUpdateAtom } from 'store/vault-pools.store';
 import { formatToCurrency } from 'utils/formatToCurrency';
 
@@ -42,7 +36,16 @@ export const Add = memo(() => {
   const setTriggerUserStatsUpdate = useSetAtom(triggerUserStatsUpdateAtom);
   const [isSDKConnected] = useAtom(sdkConnectedAtom);
   const [poolTokenDecimals] = useAtom(poolTokenDecimalsAtom);
-  const [poolTokenBalance] = useAtom(poolTokenBalanceAtom);
+
+  const { data: poolTokenBalanceResult } = useBalance({
+    address,
+    token: selectedPool?.marginTokenAddr as Address,
+    enabled: !!selectedPool?.marginTokenAddr,
+  });
+
+  const poolTokenBalance = useMemo(() => {
+    return poolTokenBalanceResult ? Number(poolTokenBalanceResult.formatted) : undefined;
+  }, [poolTokenBalanceResult]);
 
   const [addAmount, setAddAmount] = useState(0);
   const [requestSent, setRequestSent] = useState(false);

--- a/src/pages/vault-page/components/liquidity-block/elements/actions/Withdraw.tsx
+++ b/src/pages/vault-page/components/liquidity-block/elements/actions/Withdraw.tsx
@@ -1,8 +1,8 @@
 import { useAtom, useSetAtom } from 'jotai';
-import { memo, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
-import { type Address, useWaitForTransaction, useWalletClient, useNetwork } from 'wagmi';
+import { type Address, useWaitForTransaction, useWalletClient, useNetwork, useContractRead } from 'wagmi';
 
 import { Box, Button, Typography } from '@mui/material';
 
@@ -17,6 +17,7 @@ import {
   triggerUserStatsUpdateAtom,
   triggerWithdrawalsUpdateAtom,
   userAmountAtom,
+  withdrawalOnChainAtom,
   withdrawalsAtom,
 } from 'store/vault-pools.store';
 import { formatToCurrency } from 'utils/formatToCurrency';
@@ -25,6 +26,7 @@ import { Initiate } from './Initiate';
 
 import styles from './Action.module.scss';
 import { getTxnLink } from 'helpers/getTxnLink';
+import { PROXY_ABI } from '@d8x/perpetuals-sdk';
 
 interface WithdrawPropsI {
   withdrawOn: string;
@@ -39,6 +41,7 @@ export const Withdraw = memo(({ withdrawOn }: WithdrawPropsI) => {
   const [withdrawals] = useAtom(withdrawalsAtom);
   const setTriggerWithdrawalsUpdate = useSetAtom(triggerWithdrawalsUpdateAtom);
   const setTriggerUserStatsUpdate = useSetAtom(triggerUserStatsUpdateAtom);
+  const [hasOpenRequestOnChain, setWithrawalOnChain] = useAtom(withdrawalOnChainAtom);
 
   const { chain } = useNetwork();
   const { data: walletClient } = useWalletClient();
@@ -47,6 +50,24 @@ export const Withdraw = memo(({ withdrawOn }: WithdrawPropsI) => {
   const [txHash, setTxHash] = useState<Address | undefined>(undefined);
 
   const requestSentRef = useRef(false);
+
+  const { data: openRequests, refetch: refetchOnChainStatus } = useContractRead({
+    address: liqProvTool?.getProxyAddress() as Address,
+    abi: PROXY_ABI,
+    enabled: !!liqProvTool && !!selectedPool,
+    functionName: 'getWithdrawRequests',
+    args: [selectedPool?.poolId, 0, 256],
+  });
+
+  useEffect(() => {
+    if (!openRequests || !walletClient) {
+      return undefined;
+    }
+    const res = (openRequests as unknown[]).some(
+      (req) => (req as { lp: string }).lp.toLowerCase() === walletClient.account.address.toLowerCase()
+    );
+    setWithrawalOnChain(res);
+  }, [openRequests, walletClient, setWithrawalOnChain]);
 
   useWaitForTransaction({
     hash: txHash,
@@ -83,6 +104,7 @@ export const Withdraw = memo(({ withdrawOn }: WithdrawPropsI) => {
     onSettled() {
       setTxHash(undefined);
       setTriggerUserStatsUpdate((prevValue) => !prevValue);
+      refetchOnChainStatus();
     },
     enabled: !!txHash,
   });
@@ -173,7 +195,7 @@ export const Withdraw = memo(({ withdrawOn }: WithdrawPropsI) => {
         </Typography>
       </Box>
       <Box className={styles.contentBlock}>
-        {!withdrawals.length && (
+        {!withdrawals.length && !hasOpenRequestOnChain && (
           <>
             <Initiate />
             <Separator className={styles.separator} />

--- a/src/pages/vault-page/components/personal-stats/PersonalStats.tsx
+++ b/src/pages/vault-page/components/personal-stats/PersonalStats.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { memo, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAccount, useChainId } from 'wagmi';
@@ -8,7 +8,13 @@ import { Box, Typography } from '@mui/material';
 import { InfoLabelBlock } from 'components/info-label-block/InfoLabelBlock';
 import { getEarnings } from 'network/history';
 import { selectedPoolAtom, traderAPIAtom } from 'store/pools.store';
-import { sdkConnectedAtom, triggerUserStatsUpdateAtom, userAmountAtom, withdrawalsAtom } from 'store/vault-pools.store';
+import {
+  sdkConnectedAtom,
+  triggerUserStatsUpdateAtom,
+  userAmountAtom,
+  withdrawalOnChainAtom,
+  withdrawalsAtom,
+} from 'store/vault-pools.store';
 import { formatToCurrency } from 'utils/formatToCurrency';
 
 import styles from './PersonalStats.module.scss';
@@ -28,6 +34,7 @@ export const PersonalStats = memo(({ withdrawOn }: PersonalStatsPropsI) => {
   const [traderAPI] = useAtom(traderAPIAtom);
   const [triggerUserStatsUpdate] = useAtom(triggerUserStatsUpdateAtom);
   const [isSDKConnected] = useAtom(sdkConnectedAtom);
+  const hasOpenRequestOnChain = useAtomValue(withdrawalOnChainAtom);
 
   const [estimatedEarnings, setEstimatedEarnings] = useState<number>();
 
@@ -121,7 +128,7 @@ export const PersonalStats = memo(({ withdrawOn }: PersonalStatsPropsI) => {
           />
         </Box>
         <Typography variant="bodyMedium" className={styles.statValue}>
-          {withdrawals && withdrawals.length > 0 ? 'Yes' : 'No'}
+          {(withdrawals && withdrawals.length > 0) || hasOpenRequestOnChain ? 'Yes' : 'No'}
         </Typography>
       </Box>
       <Box key="withdrawalAmount" className={styles.statContainer}>

--- a/src/store/vault-pools.store.ts
+++ b/src/store/vault-pools.store.ts
@@ -13,3 +13,4 @@ export const userAmountAtom = atom<number | null>(null);
 export const triggerWithdrawalsUpdateAtom = atom(true);
 export const triggerUserStatsUpdateAtom = atom(true);
 export const sdkConnectedAtom = atom(false);
+export const withdrawalOnChainAtom = atom(false);


### PR DESCRIPTION
- pool token balance is fetched when add-liquidity page is rendered (previously you had to refresh to get the latest balance)
- d token balance is already fetched as soon as it's needed, no change there
- fetch list of liquidity withdrawals on-chain as additional check for the initiate/execute page