### PR TITLE
Edge cases when polling

### DIFF
--- a/src/components/order-block/elements/order-size/OrderSize.tsx
+++ b/src/components/order-block/elements/order-size/OrderSize.tsx
@@ -180,7 +180,12 @@ export const OrderSize = memo(() => {
     setOpenCurrencySelector(false);
   };
 
-  const maxOrderSizeCurrent = maxOrderSize && maxOrderSize * currencyMultiplier;
+  const maxOrderSizeCurrent = useMemo(() => {
+    if (maxOrderSize !== undefined) {
+      return maxOrderSize && maxOrderSize * currencyMultiplier;
+    }
+  }, [maxOrderSize, currencyMultiplier]);
+
   return (
     <>
       <Box className={styles.root}>

--- a/src/context/websocket-context/d8x/useWsMessageHandler.tsx
+++ b/src/context/websocket-context/d8x/useWsMessageHandler.tsx
@@ -212,7 +212,6 @@ export function useWsMessageHandler() {
         removeOpenOrder(orderId);
         if (!executedOrders.has(orderId)) {
           setOrderExecuted(orderId);
-          console.log('from event');
           toast.success(
             <ToastContent
               title={t('pages.trade.positions-table.toasts.trade-executed.title')}

--- a/src/pages/trader-page/components/table-data-refetcher/TableDataFetcher.tsx
+++ b/src/pages/trader-page/components/table-data-refetcher/TableDataFetcher.tsx
@@ -4,7 +4,14 @@ import { type Address, useAccount, useChainId } from 'wagmi';
 
 import { getOpenOrders, getPositionRisk } from 'network/network';
 import { latestOrderSentTimestampAtom } from 'store/order-block.store';
-import { clearOpenOrdersAtom, executeOrderAtom, openOrdersAtom, positionsAtom, traderAPIAtom } from 'store/pools.store';
+import {
+  clearOpenOrdersAtom,
+  executeOrderAtom,
+  failOrderIdAtom,
+  openOrdersAtom,
+  positionsAtom,
+  traderAPIAtom,
+} from 'store/pools.store';
 import { PerpetualOpenOrdersI } from 'types/types';
 import { OrderStatus } from '@d8x/perpetuals-sdk';
 import { toast } from 'react-toastify';
@@ -25,6 +32,7 @@ export const TableDataFetcher = memo(() => {
   const [traderAPI] = useAtom(traderAPIAtom);
   const [openOrders, setOpenOrders] = useAtom(openOrdersAtom);
   const [executedOrders, setOrderExecuted] = useAtom(executeOrderAtom);
+  const [failedOrderIds, setOrderIdFailed] = useAtom(failOrderIdAtom);
 
   const clearOpenOrders = useSetAtom(clearOpenOrdersAtom);
   const setPositions = useSetAtom(positionsAtom);
@@ -83,7 +91,8 @@ export const TableDataFetcher = memo(() => {
               />
             );
           }
-          if (orderStatus === OrderStatus.CANCELED) {
+          if (orderStatus === OrderStatus.CANCELED && !failedOrderIds.has(order.id)) {
+            setOrderIdFailed(order.id);
             toast.error(
               <ToastContent
                 title={t('pages.trade.positions-table.toasts.order-failed.title')}
@@ -99,7 +108,7 @@ export const TableDataFetcher = memo(() => {
         }
       }
     },
-    [executedOrders, t, openOrders, traderAPI, setOrderExecuted]
+    [executedOrders, failedOrderIds, t, openOrders, traderAPI, setOrderExecuted, setOrderIdFailed]
   );
 
   useEffect(() => {

--- a/src/pages/trader-page/components/table-data-refetcher/TableDataFetcher.tsx
+++ b/src/pages/trader-page/components/table-data-refetcher/TableDataFetcher.tsx
@@ -1,40 +1,50 @@
 import { useAtom, useSetAtom } from 'jotai';
-import { memo, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import { type Address, useAccount, useChainId } from 'wagmi';
 
 import { getOpenOrders, getPositionRisk } from 'network/network';
 import { latestOrderSentTimestampAtom } from 'store/order-block.store';
-import { clearOpenOrdersAtom, openOrdersAtom, positionsAtom, traderAPIAtom } from 'store/pools.store';
+import { clearOpenOrdersAtom, executeOrderAtom, openOrdersAtom, positionsAtom, traderAPIAtom } from 'store/pools.store';
+import { PerpetualOpenOrdersI } from 'types/types';
+import { OrderStatus } from '@d8x/perpetuals-sdk';
+import { toast } from 'react-toastify';
+import { ToastContent } from 'components/toast-content/ToastContent';
+import { useTranslation } from 'react-i18next';
 
 const MAX_FETCH_COUNT = 20;
 const MAX_FETCH_TIME = 40 * 1000;
-const INTERVAL_FOR_TICKER = 2000;
+const INTERVAL_FOR_TICKER_FAST = 2000;
+const INTERVAL_FOR_TICKER_SLOW = 60000;
 
 export const TableDataFetcher = memo(() => {
+  const { t } = useTranslation();
   const { address } = useAccount();
   const chainId = useChainId();
 
   const [latestOrderSentTimestamp] = useAtom(latestOrderSentTimestampAtom);
   const [traderAPI] = useAtom(traderAPIAtom);
+  const [openOrders, setOpenOrders] = useAtom(openOrdersAtom);
+  const [executedOrders, setOrderExecuted] = useAtom(executeOrderAtom);
+
   const clearOpenOrders = useSetAtom(clearOpenOrdersAtom);
-  const setOpenOrders = useSetAtom(openOrdersAtom);
   const setPositions = useSetAtom(positionsAtom);
 
-  const [ticker, setTicker] = useState(0);
+  const [fastTicker, setFastTicker] = useState(0);
+  const [slowTicker, setSlowTicker] = useState(0);
 
   useEffect(() => {
     let intervalId: NodeJS.Timeout;
     if (Date.now() - latestOrderSentTimestamp <= MAX_FETCH_TIME) {
-      setTicker(1);
+      setFastTicker(1);
       intervalId = setInterval(() => {
-        setTicker((prevState) => {
+        setFastTicker((prevState) => {
           if (prevState >= MAX_FETCH_COUNT) {
             clearInterval(intervalId);
             return 0;
           }
           return prevState + 1;
         });
-      }, INTERVAL_FOR_TICKER);
+      }, INTERVAL_FOR_TICKER_FAST);
     }
     return () => {
       clearInterval(intervalId);
@@ -42,9 +52,57 @@ export const TableDataFetcher = memo(() => {
   }, [latestOrderSentTimestamp]);
 
   useEffect(() => {
-    if (ticker > 0 && chainId && address) {
+    setInterval(() => {
+      setSlowTicker((prevState) => {
+        return prevState + 1;
+      });
+    }, INTERVAL_FOR_TICKER_SLOW);
+  }, []);
+
+  const handleRemovedOrders = useCallback(
+    async (newOrderInfo: PerpetualOpenOrdersI[]) => {
+      for (const order of openOrders) {
+        if (!newOrderInfo.some(({ orderIds }) => orderIds.some((orderId) => order.id === orderId))) {
+          const orderStatus = await traderAPI?.getOrderStatus(order.symbol, order.id);
+          if (orderStatus === OrderStatus.EXECUTED && !executedOrders.has(order.id)) {
+            console.log('from callback');
+            setOrderExecuted(order.id);
+            toast.success(
+              <ToastContent
+                title={t('pages.trade.positions-table.toasts.trade-executed.title')}
+                bodyLines={[
+                  {
+                    label: t('pages.trade.positions-table.toasts.trade-executed.body'),
+                    value: order.symbol,
+                  },
+                ]}
+              />
+            );
+          }
+          if (orderStatus === OrderStatus.CANCELED) {
+            toast.error(
+              <ToastContent
+                title={t('pages.trade.positions-table.toasts.order-failed.title')}
+                bodyLines={[
+                  {
+                    label: t('pages.trade.positions-table.toasts.order-failed.body1'),
+                    value: order.symbol,
+                  },
+                ]}
+              />
+            );
+          }
+        }
+      }
+    },
+    [openOrders, executedOrders, traderAPI, t, setOrderExecuted]
+  );
+
+  useEffect(() => {
+    if ((fastTicker > 0 || slowTicker > 0) && chainId && address) {
       getOpenOrders(chainId, traderAPI, address as Address)
         .then(({ data: d }) => {
+          handleRemovedOrders(d).then();
           clearOpenOrders();
           if (d?.length > 0) {
             d.map(setOpenOrders);
@@ -59,7 +117,17 @@ export const TableDataFetcher = memo(() => {
         })
         .catch(console.error);
     }
-  }, [ticker, chainId, traderAPI, address, setPositions, setOpenOrders, clearOpenOrders]);
+  }, [
+    slowTicker,
+    fastTicker,
+    chainId,
+    traderAPI,
+    address,
+    handleRemovedOrders,
+    setPositions,
+    setOpenOrders,
+    clearOpenOrders,
+  ]);
 
   return null;
 });

--- a/src/pages/trader-page/components/table-data-refetcher/TableDataFetcher.tsx
+++ b/src/pages/trader-page/components/table-data-refetcher/TableDataFetcher.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next';
 const MAX_FETCH_COUNT = 20;
 const MAX_FETCH_TIME = 40 * 1000;
 const INTERVAL_FOR_TICKER_FAST = 2000;
-const INTERVAL_FOR_TICKER_SLOW = 60000;
+const INTERVAL_FOR_TICKER_SLOW = 120000;
 
 export const TableDataFetcher = memo(() => {
   const { t } = useTranslation();
@@ -63,7 +63,6 @@ export const TableDataFetcher = memo(() => {
 
   const handleRemovedOrders = useCallback(
     async (newOrderInfo: PerpetualOpenOrdersI[]) => {
-      console.log(openOrders, executedOrders, traderAPI);
       if (newOrderInfo.length < 1 || !traderAPI) {
         return;
       }
@@ -71,7 +70,6 @@ export const TableDataFetcher = memo(() => {
         if (!newOrderInfo.some(({ orderIds }) => orderIds.some((orderId) => order.id === orderId))) {
           const orderStatus = await traderAPI.getOrderStatus(order.symbol, order.id);
           if (orderStatus === OrderStatus.EXECUTED && !executedOrders.has(order.id)) {
-            console.log('from callback');
             setOrderExecuted(order.id);
             toast.success(
               <ToastContent
@@ -135,7 +133,6 @@ export const TableDataFetcher = memo(() => {
     address,
     lastFetch,
     handleRemovedOrders,
-    // setLastFetch,
     setPositions,
     setOpenOrders,
     clearOpenOrders,

--- a/src/store/pools.store.ts
+++ b/src/store/pools.store.ts
@@ -223,3 +223,17 @@ export const executeOrderAtom = atom(
     });
   }
 );
+
+const failedOrderIdsAtom = atom<Set<string>>(new Set<string>());
+
+export const failOrderIdAtom = atom(
+  (get) => {
+    return get(failedOrderIdsAtom);
+  },
+  (_get, set, orderId: string) => {
+    set(failedOrderIdsAtom, (prev) => {
+      prev.add(orderId);
+      return prev;
+    });
+  }
+);

--- a/src/store/pools.store.ts
+++ b/src/store/pools.store.ts
@@ -209,3 +209,17 @@ export const failOrderAtom = atom(null, (_get, set, orderIdToUpdate: string) => 
 export const clearOpenOrdersAtom = atom(null, (_get, set) => {
   set(ordersAtom, {});
 });
+
+const executedOrdersAtom = atom<Set<string>>(new Set<string>());
+
+export const executeOrderAtom = atom(
+  (get) => {
+    return get(executedOrdersAtom);
+  },
+  (_get, set, orderId: string) => {
+    set(executedOrdersAtom, (prev) => {
+      prev.add(orderId);
+      return prev;
+    });
+  }
+);


### PR DESCRIPTION
- Adds a slow/constant polling of open orders on top of the "fast" one done with every order submission
- Adds a set of executed order ids. A trade toast is shown if either:
    -  a ws message is received from the backend
    - an order disappears from the open orders table and its status is executed
    - only one of the above triggers a toast (the first to be triggered)
- Equivalent logic for failed orders (set of ids tracks what has been seen, a toast appears either because of a ws update or a regular interval check, whichever comes first)