### PR TITLE
Dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ VITE_FIREBASE_MESSAGINGSENDERID=
 VITE_FIREBASE_APPID=
 VITE_FIREBASE_MEASUREMENTID=
 
-VITE_ACTIVATE_LIFI=true
+VITE_ENABLED_LIFI_BY_CHAINS=1442;80001
 VITE_ENABLED_CHAINS=1442;80001
 VITE_API_URL=137::https://api.dev2.quantena.tech;80001::https://api.dev2.quantena.tech;1442::https://api.zktest.quantena.tech;default::https://api.dev2.quantena.tech
 VITE_BROKER_URL=

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ This package is configured entirely via environment variables. You must specify:
   - This entry should then take the form:
     `VITE_ENABLED_CHAINS=1101;1442`
 
-- **VITE_ACTIVATE_LIFI**: This is an optional variable that allow to disable LIFI widget. It could be required when app
-  is tested with testnet. The LIFI widget doesn't work with testnet.
+- **VITE_ENABLED_LIFI_BY_CHAINS**: This is an optional variable that enables the LiFi widget by chains.
 
-  - By default, this variable is set to `true`.
-  - If it is required to be disabled then it should take the form:
-    `VITE_ACTIVATE_LIFI=false`
+  - By default, the LiFi widget is not shown.
+  - If it is required to be enabled for specific chains then it should take the form:
+    `VITE_ENABLED_LIFI_BY_CHAINS=1101;1442`
 
 - **VITE_ENABLED_REFER_PAGE**: This is an optional variable that allow to disable Refer page.
 
@@ -152,7 +151,7 @@ This package is configured entirely via environment variables. You must specify:
   - Enable it as follows:
     `VITE_WELCOME_MODAL=true`
 
-- **VITE_DEFAULT_THEME**: This is an optional variable that allows to define the default color theme. You can 
+- **VITE_DEFAULT_THEME**: This is an optional variable that allows to define the default color theme. You can
   use `light` or `dark`.
 
   - By default, this variable is set to `light`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mui/material": "5.15.15",
         "@mui/utils": "5.15.14",
         "@noble/secp256k1": "2.1.0",
-        "@rainbow-me/rainbowkit": "2.0.5",
+        "@rainbow-me/rainbowkit": "2.0.7",
         "@tanstack/react-query": "5.31.0",
         "@wagmi/core": "2.6.17",
         "@web3auth/base": "8.3.0",
@@ -2306,9 +2306,9 @@
       }
     },
     "node_modules/@coinbase/wallet-sdk": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.9.2.tgz",
-      "integrity": "sha512-SyfUlG0DzgRu2WQ8+c7DpFEIe8Bt/nxyP1hcExDUXF7cHaopdAU43djT8SLIWH8Li40ZK9VBGVuNIK/pwHR9LA==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.9.3.tgz",
+      "integrity": "sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==",
       "dependencies": {
         "bn.js": "^5.2.1",
         "buffer": "^6.0.3",
@@ -6437,10 +6437,11 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rainbow-me/rainbowkit": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-2.0.5.tgz",
-      "integrity": "sha512-JVBgl0J1EvYXrGxDJmqEVMFrjE3gGidHyacFilKu/zJdaHFGXogsmCG51DdaU3gsas0Aqbq9kqK13qk49VSfAg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-2.0.7.tgz",
+      "integrity": "sha512-S+f7oHKsuKsddqLEdH/yyjxLgqTF6P6/+y9xDMgY9BqMVSEIn4nTlkec4fphzrVNeg/kzizCzQgF0yRHwHkLlw==",
       "dependencies": {
+        "@coinbase/wallet-sdk": "3.9.3",
         "@vanilla-extract/css": "1.14.0",
         "@vanilla-extract/dynamic": "2.1.0",
         "@vanilla-extract/sprinkles": "1.6.1",
@@ -6453,8 +6454,8 @@
         "node": ">=12.4"
       },
       "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17",
+        "react": ">=18",
+        "react-dom": ">=18",
         "viem": "2.x",
         "wagmi": "2.x"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@mui/material": "5.15.15",
     "@mui/utils": "5.15.14",
     "@noble/secp256k1": "2.1.0",
-    "@rainbow-me/rainbowkit": "2.0.5",
+    "@rainbow-me/rainbowkit": "2.0.7",
     "@tanstack/react-query": "5.31.0",
     "@wagmi/core": "2.6.17",
     "@web3auth/base": "8.3.0",

--- a/patches/@rainbow-me+rainbowkit+2.0.7.patch
+++ b/patches/@rainbow-me+rainbowkit+2.0.7.patch
@@ -1,0 +1,79 @@
+diff --git a/node_modules/@rainbow-me/rainbowkit/dist/components/RainbowKitProvider/RainbowKitChainContext.d.ts b/node_modules/@rainbow-me/rainbowkit/dist/components/RainbowKitProvider/RainbowKitChainContext.d.ts
+index b63cc28..1934e4d 100644
+--- a/node_modules/@rainbow-me/rainbowkit/dist/components/RainbowKitProvider/RainbowKitChainContext.d.ts
++++ b/node_modules/@rainbow-me/rainbowkit/dist/components/RainbowKitProvider/RainbowKitChainContext.d.ts
+@@ -6,9 +6,10 @@ export interface RainbowKitChain extends Chain {
+ }
+ interface RainbowKitChainProviderProps {
+     initialChain?: Chain | number;
++    visibleChains: number[];
+     children: ReactNode;
+ }
+-export declare function RainbowKitChainProvider({ children, initialChain, }: RainbowKitChainProviderProps): React.JSX.Element;
++export declare function RainbowKitChainProvider({ children, initialChain, visibleChains, }: RainbowKitChainProviderProps): React.JSX.Element;
+ export declare const useRainbowKitChains: () => RainbowKitChain[];
+ export declare const useInitialChainId: () => number | undefined;
+ export declare const useRainbowKitChainsById: () => Record<number, RainbowKitChain>;
+diff --git a/node_modules/@rainbow-me/rainbowkit/dist/components/RainbowKitProvider/RainbowKitProvider.d.ts b/node_modules/@rainbow-me/rainbowkit/dist/components/RainbowKitProvider/RainbowKitProvider.d.ts
+index fe12c34..7fc338d 100644
+--- a/node_modules/@rainbow-me/rainbowkit/dist/components/RainbowKitProvider/RainbowKitProvider.d.ts
++++ b/node_modules/@rainbow-me/rainbowkit/dist/components/RainbowKitProvider/RainbowKitProvider.d.ts
+@@ -14,6 +14,7 @@ export type Theme = ThemeVars | {
+ };
+ export interface RainbowKitProviderProps {
+     initialChain?: Chain | number;
++    visibleChains?: number[];
+     id?: string;
+     children: ReactNode;
+     theme?: Theme | null;
+@@ -28,4 +29,4 @@ export interface RainbowKitProviderProps {
+     modalSize?: ModalSizes;
+     locale?: Locale;
+ }
+-export declare function RainbowKitProvider({ appInfo, avatar, children, coolMode, id, initialChain, locale, modalSize, showRecentTransactions, theme, }: RainbowKitProviderProps): React.JSX.Element;
++export declare function RainbowKitProvider({ appInfo, avatar, children, coolMode, id, initialChain, visibleChains, locale, modalSize, showRecentTransactions, theme, }: RainbowKitProviderProps): React.JSX.Element;
+diff --git a/node_modules/@rainbow-me/rainbowkit/dist/index.js b/node_modules/@rainbow-me/rainbowkit/dist/index.js
+index eab78f6..d82dc17 100644
+--- a/node_modules/@rainbow-me/rainbowkit/dist/index.js
++++ b/node_modules/@rainbow-me/rainbowkit/dist/index.js
+@@ -883,14 +883,19 @@ var RainbowKitChainContext = createContext4({
+ });
+ function RainbowKitChainProvider({
+   children,
+-  initialChain
++  initialChain,
++  visibleChains
+ }) {
+   const { chains } = useConfig();
++  let availableChains = chains;
++  if (visibleChains.length > 0) {
++    availableChains = availableChains.filter(({ id }) => visibleChains.includes(id));
++  }
+   return /* @__PURE__ */ React10.createElement(RainbowKitChainContext.Provider, {
+     value: useMemo5(() => ({
+-      chains: provideRainbowKitChains(chains),
++      chains: provideRainbowKitChains(availableChains),
+       initialChainId: typeof initialChain === "number" ? initialChain : initialChain == null ? void 0 : initialChain.id
+-    }), [chains, initialChain])
++    }), [availableChains, initialChain])
+   }, children);
+ }
+ var useRainbowKitChains = () => useContext3(RainbowKitChainContext).chains;
+@@ -1999,6 +2004,7 @@ function RainbowKitProvider({
+   coolMode = false,
+   id,
+   initialChain,
++  visibleChains,
+   locale,
+   modalSize = ModalSizeOptions.WIDE,
+   showRecentTransactions = false,
+@@ -2017,7 +2023,8 @@ function RainbowKitProvider({
+   };
+   const avatarContext = avatar != null ? avatar : defaultAvatar;
+   return /* @__PURE__ */ React23.createElement(RainbowKitChainProvider, {
+-    initialChain
++    initialChain,
++    visibleChains: visibleChains || []
+   }, /* @__PURE__ */ React23.createElement(WalletButtonProvider, null, /* @__PURE__ */ React23.createElement(I18nProvider, {
+     locale
+   }, /* @__PURE__ */ React23.createElement(CoolModeContext.Provider, {

--- a/public/locales/cn/translations.json
+++ b/public/locales/cn/translations.json
@@ -810,7 +810,7 @@
         "label2": "流动性池：",
         "headers": {
           "collateral": "抵押品",
-          "num-of-perps": "永续人数"
+          "num-of-perps": "交易对数量"
         }
       },
       "market": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -3,7 +3,7 @@
     "trade": "Trade",
     "boost-station": "BoostStation",
     "refer": "Refer",
-    "vault": "Vault",
+    "vault": "Earn",
     "strategies": "Strategies",
     "portfolio": "Portfolio"
   },
@@ -665,7 +665,7 @@
     },
     "portfolio": {
       "perpetuals": "Perpetuals",
-      "vault": "Vault",
+      "vault": "Earn",
       "account-value": {
         "main-title": "Your account",
         "title": "Account Value",
@@ -683,7 +683,7 @@
             "referral": "Referral earnings"
           },
           "vault": {
-            "title": "Vault details",
+            "title": "Earn details",
             "assets": "Assets",
             "assets-pool": "Assets in pools",
             "earnings-pool": "Earnings per pool",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import 'core-js/es/string';
 
 import styles from './App.module.scss';
 import { useAccount } from 'wagmi';
+import { LiFiWidgetModal } from './components/li-fi-widget-modal/LiFiWidgetModal';
 
 export const App = memo(() => {
   const { width, height, ref } = useResizeDetector();
@@ -62,6 +63,7 @@ export const App = memo(() => {
         <WelcomeModal />
         <ReferralConfirmModal />
         {!isSignedInSocially && isConnected && <OneClickTradingModal />}
+        {isConnected && <LiFiWidgetModal />}
         <ToastContainerWrapper />
       </Box>
     </Box>

--- a/src/RainbowKitProviderWrapper.tsx
+++ b/src/RainbowKitProviderWrapper.tsx
@@ -3,6 +3,7 @@ import { useAtomValue } from 'jotai';
 import { ReactNode } from 'react';
 
 import { Disclaimer } from 'components/disclaimer/disclaimer';
+import { config } from 'config';
 import { enabledDarkModeAtom } from 'store/app.store';
 
 import '@rainbow-me/rainbowkit/styles.css';
@@ -15,6 +16,7 @@ export const RainbowKitProviderWrapper = ({ children }: { children: ReactNode })
       appInfo={{ appName: 'D8X', disclaimer: Disclaimer, learnMoreUrl: 'https://d8x.exchange/' }}
       modalSize="compact"
       theme={enabledDarkMode ? darkTheme() : undefined}
+      visibleChains={config.enabledChains}
     >
       {children}
     </RainbowKitProvider>

--- a/src/blockchain-api/wagmi/wagmiClient.ts
+++ b/src/blockchain-api/wagmi/wagmiClient.ts
@@ -8,7 +8,30 @@ import {
   rainbowWallet,
   walletConnectWallet,
 } from '@rainbow-me/rainbowkit/wallets';
-import { polygonMumbai, polygonZkEvm, polygonZkEvmTestnet, arbitrumSepolia, arbitrum } from 'wagmi/chains';
+import {
+  polygon,
+  polygonMumbai,
+  polygonZkEvm,
+  arbitrumSepolia,
+  arbitrum,
+  mainnet,
+  optimism,
+  bsc,
+  base,
+  zkSync,
+  avalanche,
+  aurora,
+  linea,
+  gnosis,
+  fantom,
+  moonriver,
+  moonbeam,
+  fuse,
+  boba,
+  metis,
+  mode,
+  scroll,
+} from 'wagmi/chains';
 import { createConfig, http } from 'wagmi';
 import { createClient } from 'viem';
 
@@ -22,7 +45,6 @@ import { x1, cardona, artio, xlayer } from 'utils/chains';
 const chains = [
   { ...polygonZkEvm, iconUrl: polygonIcon, iconBackground: 'transparent' } as Chain,
   { ...polygonMumbai, iconUrl: polygonIcon, iconBackground: 'transparent' },
-  { ...polygonZkEvmTestnet, iconUrl: polygonIcon, iconBackground: 'transparent' },
   { ...x1, iconUrl: x1Icon, iconBackground: 'transparent' },
   { ...xlayer, iconUrl: x1Icon, iconBackground: 'transparent' },
   { ...cardona, iconUrl: polygonIcon, iconBackground: 'transparent' },
@@ -49,9 +71,26 @@ const chains = [
       },
     },
   },
-]
-  .filter(({ id }) => config.enabledChains.includes(id))
-  .sort(({ id: id1 }, { id: id2 }) => config.enabledChains.indexOf(id1) - config.enabledChains.indexOf(id2)) as [
+  // LiFi specific chains
+  { ...mainnet },
+  { ...optimism },
+  { ...polygon },
+  { ...bsc },
+  { ...zkSync },
+  { ...base },
+  { ...avalanche },
+  { ...aurora },
+  { ...linea },
+  { ...gnosis },
+  { ...fantom },
+  { ...moonriver },
+  { ...moonbeam },
+  { ...fuse },
+  { ...boba },
+  { ...metis },
+  { ...mode },
+  { ...scroll },
+].sort(({ id: id1 }, { id: id2 }) => config.enabledChains.indexOf(id1) - config.enabledChains.indexOf(id2)) as [
   Chain,
   ...Chain[],
 ];

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -413,6 +413,7 @@ export const Header = memo(({ window }: HeaderPropsI) => {
               <div className={styles.mobileButtonsBlock}>
                 <Separator />
                 <div className={styles.mobileWalletButtons}>
+                  <WalletConnectButton />
                   <WalletConnectedButtons />
                 </div>
               </div>

--- a/src/components/header/elements/market-select/components/search-input/SearchInput.tsx
+++ b/src/components/header/elements/market-select/components/search-input/SearchInput.tsx
@@ -2,8 +2,7 @@ import { atom, useAtom } from 'jotai';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import ClearIcon from '@mui/icons-material/Clear';
-import SearchIcon from '@mui/icons-material/Search';
+import { Clear, Search } from '@mui/icons-material';
 
 import styles from './SearchInput.module.scss';
 
@@ -25,8 +24,8 @@ export const SearchInput = memo(() => {
         placeholder={t('common.select.search')}
         value={searchFilter}
       />
-      <SearchIcon className={styles.searchIcon} style={{ color: 'var(--d8x-color-icon)' }} />
-      {searchFilter && <ClearIcon className={styles.closeIcon} onClick={() => setSearchFilter('')} />}
+      <Search className={styles.searchIcon} style={{ color: 'var(--d8x-color-icon)' }} />
+      {searchFilter && <Clear className={styles.closeIcon} onClick={() => setSearchFilter('')} />}
     </div>
   );
 });

--- a/src/components/li-fi-widget-modal/LiFiWidgetModal.module.scss
+++ b/src/components/li-fi-widget-modal/LiFiWidgetModal.module.scss
@@ -5,6 +5,11 @@
   flex-direction: column;
   gap: 8 * $d8x-spacing;
   padding: 10 * $d8x-spacing 8 * $d8x-spacing;
+  background-color: var(--d8x-color-background);
+
+  :global(.MuiScopedCssBaseline-root) {
+    background-color: var(--d8x-color-background);
+  }
 }
 
 .closeButton {
@@ -19,6 +24,27 @@
 }
 
 @media screen and ($d8x-breakpoint-max-xs) {
+  .dialogContent {
+    gap: 2 * $d8x-spacing;
+    padding: 3 * $d8x-spacing 4 * $d8x-spacing;
+
+    :global(.MuiContainer-root) {
+      > :global(.MuiBox-root) {
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+
+        > :global(.MuiPaper-root) {
+          margin-left: 0 !important;
+          margin-right: 0 !important;
+          padding-left: 0 !important;
+          padding-right: 0 !important;
+        }
+      }
+    }
+  }
+
   .closeButton {
     width: 100%;
     height: 50px;

--- a/src/components/li-fi-widget-modal/LiFiWidgetModal.tsx
+++ b/src/components/li-fi-widget-modal/LiFiWidgetModal.tsx
@@ -1,18 +1,20 @@
-import { Box, Button } from '@mui/material';
+import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
+
+import { Box, Button } from '@mui/material';
 
 import { Dialog } from 'components/dialog/Dialog';
 import { LiFiWidgetHolder } from 'components/li-fi-widget/LiFiWidgetHolder';
+import { lifiModalOpenAtom } from 'store/global-modals.store';
 
 import styles from './LiFiWidgetModal.module.scss';
 
-interface LiFiWidgetModalPropsI {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-export const LiFiWidgetModal = ({ isOpen, onClose }: LiFiWidgetModalPropsI) => {
+export const LiFiWidgetModal = () => {
   const { t } = useTranslation();
+
+  const [isOpen, setOpen] = useAtom(lifiModalOpenAtom);
+
+  const onClose = () => setOpen(false);
 
   return (
     <Dialog open={isOpen} onCloseClick={onClose}>

--- a/src/components/li-fi-widget/LiFiWidgetHolder.tsx
+++ b/src/components/li-fi-widget/LiFiWidgetHolder.tsx
@@ -7,7 +7,7 @@ import { useChainId, useConnect, useDisconnect } from 'wagmi';
 import { getWalletClient } from '@wagmi/core';
 
 import { wagmiConfig } from 'blockchain-api/wagmi/wagmiClient';
-import { config as appConfig } from 'config';
+import { config } from 'config';
 import { useEthersSigner, walletClientToSigner } from 'hooks/useEthersSigner';
 import { enabledDarkModeAtom } from 'store/app.store';
 import { poolsAtom, selectedPoolAtom } from 'store/pools.store';
@@ -48,7 +48,7 @@ export const LiFiWidgetHolder = () => {
   const widgetConfig: WidgetConfig = useMemo(() => {
     const currentLanguage = (modifyLanguage(i18n.resolvedLanguage) as LanguageKey) || LanguageE.EN;
 
-    const config: WidgetConfig = {
+    const lifiConfig: WidgetConfig = {
       integrator: 'li-fi-widget',
       walletManagement: {
         signer,
@@ -86,7 +86,7 @@ export const LiFiWidgetHolder = () => {
         },
       },
       chains: {
-        [triggerSwap ? 'allowFrom' : 'allowTo']: [...appConfig.enabledChains],
+        [triggerSwap ? 'allowFrom' : 'allowTo']: config.enabledLiFiByChains,
       },
       tokens: {
         [triggerSwap ? 'allowFrom' : 'allowTo']: admissibleTokens,
@@ -99,8 +99,13 @@ export const LiFiWidgetHolder = () => {
         // TODO: Might be change later in this way
         // deny: ['dodo', '0x'],
       },
+      // Styles
+      containerStyle: {
+        backgroundColor: 'transparent',
+        minWidth: 'auto',
+      },
     };
-    return config;
+    return lifiConfig;
   }, [triggerSwap, chainId, selectedPool, signer, connectors, disconnect, t, i18n, enabledDarkMode, admissibleTokens]);
 
   useEffect(() => {

--- a/src/components/table-selector/elements/refresher/Refresher.tsx
+++ b/src/components/table-selector/elements/refresher/Refresher.tsx
@@ -1,8 +1,8 @@
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 
+import { AutorenewOutlined } from '@mui/icons-material';
 import { Box, Typography } from '@mui/material';
-import AutorenewOutlinedIcon from '@mui/icons-material/AutorenewOutlined';
 
 import { tableRefreshHandlersAtom } from 'store/tables.store';
 
@@ -20,7 +20,7 @@ export const Refresher = ({ activeTableType }: RefresherPropsI) => {
 
   return (
     <Box className={styles.root} onClick={tableRefreshHandlers[activeTableType] ?? undefined}>
-      <AutorenewOutlinedIcon className={styles.actionIcon} />
+      <AutorenewOutlined className={styles.actionIcon} />
       <Typography variant="bodySmall" className={styles.refreshLabel}>
         {t('common.refresh')}
       </Typography>

--- a/src/components/wallet-connect-button/LiFiWidgetButton.tsx
+++ b/src/components/wallet-connect-button/LiFiWidgetButton.tsx
@@ -1,28 +1,26 @@
-import { useState } from 'react';
+import { useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 
-import CurrencyExchangeOutlinedIcon from '@mui/icons-material/CurrencyExchangeOutlined';
+import { CurrencyExchangeOutlined } from '@mui/icons-material';
 import { Button } from '@mui/material';
-import { LiFiWidgetModal } from 'components/li-fi-widget-modal/LiFiWidgetModal';
+
+import { lifiModalOpenAtom } from 'store/global-modals.store';
 
 import styles from './WalletConnectButton.module.scss';
 
 export const LiFiWidgetButton = () => {
   const { t } = useTranslation();
 
-  const [isModalOpen, setModalOpen] = useState(false);
+  const setModalOpen = useSetAtom(lifiModalOpenAtom);
 
   return (
-    <>
-      <Button
-        onClick={() => setModalOpen(true)}
-        className={styles.chainButton}
-        variant="primary"
-        title={t('common.li-fi-widget.button-title')}
-      >
-        <CurrencyExchangeOutlinedIcon />
-      </Button>
-      <LiFiWidgetModal isOpen={isModalOpen} onClose={() => setModalOpen(false)} />
-    </>
+    <Button
+      onClick={() => setModalOpen(true)}
+      className={styles.chainButton}
+      variant="primary"
+      title={t('common.li-fi-widget.button-title')}
+    >
+      <CurrencyExchangeOutlined />
+    </Button>
   );
 };

--- a/src/components/wallet-connect-button/WalletConnectButton.module.scss
+++ b/src/components/wallet-connect-button/WalletConnectButton.module.scss
@@ -2,6 +2,7 @@
 
 .root {
   width: 100%;
+  text-align: center;
 
   &.connected {
     opacity: 0;

--- a/src/components/wallet-connect-button/WalletConnectButton.tsx
+++ b/src/components/wallet-connect-button/WalletConnectButton.tsx
@@ -8,6 +8,7 @@ import { Button } from '@mui/material';
 import { useWeb3Auth } from 'context/web3-auth-context/Web3AuthContext';
 
 import styles from './WalletConnectButton.module.scss';
+import { config } from '../../config';
 
 interface WalletConnectButtonPropsI {
   connectButtonLabel?: ReactNode;
@@ -29,6 +30,8 @@ export const WalletConnectButton = memo((props: WalletConnectButtonPropsI) => {
       {({ account, chain, openChainModal, openConnectModal, mounted }) => {
         const connected = mounted && account && chain;
 
+        const isVisibleChain = chain && config.enabledChains.includes(chain.id);
+
         return (
           <div className={classnames(styles.root, { [styles.connected]: !mounted })} aria-hidden={mounted}>
             {(() => {
@@ -45,7 +48,7 @@ export const WalletConnectButton = memo((props: WalletConnectButtonPropsI) => {
                 );
               }
 
-              if (chain.unsupported) {
+              if (chain.unsupported || !isVisibleChain) {
                 return (
                   <Button onClick={openChainModal} variant="warning">
                     {t('error.wrong-network')}

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ const {
   VITE_ENABLED_PORTFOLIO_PAGE: enabledPortfolioPage = 'true',
   VITE_ENABLED_STRATEGIES_PAGE_BY_CHAINS: enabledStrategiesPageByChains = '',
   VITE_DEFAULT_THEME: defaultTheme = 'light',
-  VITE_ACTIVATE_LIFI: activateLiFi = 'true',
+  VITE_ENABLED_LIFI_BY_CHAINS: enabledLifiByChains = '',
   VITE_WELCOME_MODAL: showChallengeModal = 'false',
   VITE_FIREBASE_APIKEY: firebaseApiKey = '',
   VITE_FIREBASE_AUTHDOMAIN: firebaseAuthDomain = '',
@@ -66,7 +66,7 @@ export const config = {
   priceFeedEndpoint: parseUrls(priceFeedEndpoints),
   httpRPC: parseUrls(httpRPCs),
   enabledChains: splitNumbers(enabledChains),
-  activateLiFi: activateLiFi === 'true',
+  enabledLiFiByChains: splitNumbers(enabledLifiByChains),
   showChallengeModal: showChallengeModal === 'true',
   defaultTheme,
 };

--- a/src/context/web3-auth-context/Web3AuthContext.tsx
+++ b/src/context/web3-auth-context/Web3AuthContext.tsx
@@ -19,7 +19,7 @@ import { numberToHex } from 'viem';
 import { useAccount, useChainId, useConnect, useDisconnect } from 'wagmi';
 
 import { chains } from 'blockchain-api/wagmi/wagmiClient';
-import { web3AuthConfig } from 'config';
+import { config, web3AuthConfig } from 'config';
 import { auth } from 'FireBaseConfig';
 import { accountModalOpenAtom } from 'store/global-modals.store';
 import { socialPKAtom, socialUserInfoAtom, web3AuthIdTokenAtom } from 'store/web3-auth.store';
@@ -45,17 +45,20 @@ if (web3AuthConfig.isEnabled) {
   verifier = web3AuthConfig.web3AuthVerifier;
   web3AuthNetwork = web3AuthConfig.web3AuthNetwork;
 
+  const firstVisibleChainId = config.enabledChains[0] || null;
+  const firstChain = chains.find((chain) => chain.id === firstVisibleChainId) || chains[0];
+
   const chainConfig = {
     chainNamespace: CHAIN_NAMESPACES.EIP155,
-    chainId: numberToHex(chains[0].id),
-    rpcTarget: chains[0].rpcUrls.default.http[0],
-    displayName: chains[0].name,
-    blockExplorerUrl: chains[0].blockExplorers?.default.url ?? '',
-    ticker: chains[0].nativeCurrency.symbol,
-    tickerName: chains[0].nativeCurrency.name,
-    decimals: chains[0].nativeCurrency.decimals,
-    logo: chains[0].iconUrl as string,
-    isTestnet: chains[0].testnet,
+    chainId: numberToHex(firstChain.id),
+    rpcTarget: firstChain.rpcUrls.default.http[0],
+    displayName: firstChain.name,
+    blockExplorerUrl: firstChain.blockExplorers?.default.url ?? '',
+    ticker: firstChain.nativeCurrency.symbol,
+    tickerName: firstChain.nativeCurrency.name,
+    decimals: firstChain.nativeCurrency.decimals,
+    logo: firstChain.iconUrl as string,
+    isTestnet: firstChain.testnet,
   };
 
   const privateKeyProvider = new EthereumPrivateKeyProvider({ config: { chainConfig } });

--- a/src/store/global-modals.store.ts
+++ b/src/store/global-modals.store.ts
@@ -3,5 +3,6 @@ import { atom } from 'jotai';
 export const accountModalOpenAtom = atom(false);
 export const depositModalOpenAtom = atom(false);
 export const oneClickModalOpenAtom = atom(false);
+export const lifiModalOpenAtom = atom(false);
 export const withdrawModalOpenAtom = atom(false);
 export const extractPKModalOpenAtom = atom(false);


### PR DESCRIPTION
* Restrict chains to be shown in the RainbowKit modal

* Show `Wrong network` on the mobiles

* Change translations

* Replace `Vault` in the 3 other places

* Add chains for LiFi and move LiFi modal to globals

* remove old zkevm testnet, typos

* Show LiFi widget only on Trade page and by allowed chains

* Remove redundant props for LiFi widget

---------