### PR TITLE
no fail if order is cancelled by user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@cedelabs/widgets-universal": "1.4.0",
-        "@d8x/perpetuals-sdk": "2.4.6",
+        "@d8x/perpetuals-sdk": "2.4.7",
         "@emotion/react": "11.11.4",
         "@emotion/styled": "11.11.5",
         "@ethersproject/providers": "5.7.2",
@@ -2731,10 +2731,11 @@
       }
     },
     "node_modules/@d8x/perpetuals-sdk": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@d8x/perpetuals-sdk/-/perpetuals-sdk-2.4.6.tgz",
-      "integrity": "sha512-IW95T5l3gphRR9nsHVx6WFtI3vXwwZ/tEgO1t8IbQaXql+m58zL8+UJ+p8mfXuS6JLx+8vQ1edm3hT+ff2rVPQ==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@d8x/perpetuals-sdk/-/perpetuals-sdk-2.4.7.tgz",
+      "integrity": "sha512-9lJwuDQ6hSh3ANu86zDyUi7dRUaHORdzwGI93i8FCI4VJ9+TEUysEzwqmEyDBMnSI//nuJmofjVKVZ5xn+dmOQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@typechain/ethers-v6": "^0.5.1",
         "buffer": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@cedelabs/widgets-universal": "1.4.0",
-    "@d8x/perpetuals-sdk": "2.4.6",
+    "@d8x/perpetuals-sdk": "2.4.7",
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
     "@ethersproject/providers": "5.7.2",

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -232,13 +232,6 @@ export const ActionBlock = memo(() => {
             maxShort = 0;
           }
         }
-        if (orderInfo.orderType === OrderTypeE.Market && data.data.ammPrice <= 0) {
-          if (orderInfo.orderBlock === OrderBlockE.Long) {
-            maxLong = orderInfo.size * 0.75;
-          } else {
-            maxShort = -orderInfo.size * 0.75;
-          }
-        }
         setMaxOrderSize({ maxBuy: maxLong, maxSell: maxShort });
       })
       .catch(console.error);

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -234,9 +234,9 @@ export const ActionBlock = memo(() => {
         }
         if (orderInfo.orderType === OrderTypeE.Market && data.data.ammPrice <= 0) {
           if (orderInfo.orderBlock === OrderBlockE.Long) {
-            maxLong = maxLong * 0.75;
+            maxLong = orderInfo.size * 0.75;
           } else {
-            maxShort = maxShort * 0.75;
+            maxShort = -orderInfo.size * 0.75;
           }
         }
         setMaxOrderSize({ maxBuy: maxLong, maxSell: maxShort });

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -225,7 +225,14 @@ export const ActionBlock = memo(() => {
           ? pmInitialMarginRate(orderInfo.orderBlock === OrderBlockE.Long ? 1 : -1, data.data.newPositionRisk.markPrice)
           : perpetualStaticInfo?.initialMarginRate;
 
-        if (initialMarginRate && data.data.newPositionRisk.leverage > 1 / initialMarginRate) {
+        if (initialMarginRate && data.data.newPositionRisk.leverage > Math.floor(1 / initialMarginRate)) {
+          if (orderInfo.orderBlock === OrderBlockE.Long) {
+            maxLong = 0;
+          } else {
+            maxShort = 0;
+          }
+        }
+        if (data.data.ammPrice <= 0) {
           if (orderInfo.orderBlock === OrderBlockE.Long) {
             maxLong = 0;
           } else {

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -26,7 +26,7 @@ import { calculatePrice } from 'helpers/calculatePrice';
 import { calculateProbability } from 'helpers/calculateProbability';
 import { getTxnLink } from 'helpers/getTxnLink';
 import { useDebounce } from 'helpers/useDebounce';
-import { getPerpetualPrice, orderDigest, positionRiskOnTrade } from 'network/network';
+import { orderDigest, positionRiskOnTrade } from 'network/network';
 import { tradingClientAtom } from 'store/app.store';
 import { depositModalOpenAtom } from 'store/global-modals.store';
 import { clearInputsDataAtom, latestOrderSentTimestampAtom, orderInfoAtom } from 'store/order-block.store';
@@ -123,7 +123,6 @@ const orderTypeMap: Record<OrderTypeE, string> = {
 enum ValidityCheckE {
   Empty = '-',
   Closed = 'closed',
-  OrderTooLarge = 'order-too-large',
   OrderTooSmall = 'order-too-small',
   PositionTooSmall = 'position-too-small',
   BelowMinPosition = 'below-min-position',
@@ -224,7 +223,6 @@ export const ActionBlock = memo(() => {
         const initialMarginRate = orderInfo.isPredictionMarket
           ? pmInitialMarginRate(orderInfo.orderBlock === OrderBlockE.Long ? 1 : -1, data.data.newPositionRisk.markPrice)
           : perpetualStaticInfo?.initialMarginRate;
-
         if (initialMarginRate && data.data.newPositionRisk.leverage > Math.floor(1 / initialMarginRate)) {
           if (orderInfo.orderBlock === OrderBlockE.Long) {
             maxLong = 0;
@@ -233,20 +231,11 @@ export const ActionBlock = memo(() => {
           }
         }
         setMaxOrderSize({ maxBuy: maxLong, maxSell: maxShort });
+        setPerpetualPrice(data.data.ammPrice);
       })
       .catch(console.error);
 
-    const getPerpetualPricePromise = getPerpetualPrice(mainOrder.quantity, mainOrder.symbol, traderAPI)
-      .then((data) => {
-        const perpPrice =
-          perpetualStaticInfo && TraderInterface.isPredictionMarketStatic(perpetualStaticInfo)
-            ? calculateProbability(data.data.price, orderInfo.orderBlock === OrderBlockE.Short)
-            : data.data.price;
-        setPerpetualPrice(perpPrice);
-      })
-      .catch(console.error);
-
-    Promise.all([positionRiskOnTradePromise, getPerpetualPricePromise]).finally(() => {
+    Promise.all([positionRiskOnTradePromise]).finally(() => {
       setValidityCheck(false);
     });
   };
@@ -559,15 +548,6 @@ export const ActionBlock = memo(() => {
     ) {
       return ValidityCheckE.Empty;
     }
-    let isTooLarge;
-    if (orderInfo.orderBlock === OrderBlockE.Long) {
-      isTooLarge = orderInfo.size > Math.abs(maxOrderSize.maxBuy);
-    } else {
-      isTooLarge = orderInfo.size > Math.abs(maxOrderSize.maxSell);
-    }
-    if (isTooLarge) {
-      return ValidityCheckE.OrderTooLarge;
-    }
     const isOrderTooSmall = orderInfo.size > 0 && orderInfo.size < perpetualStaticInfo.lotSizeBC;
     if (isOrderTooSmall) {
       return ValidityCheckE.OrderTooSmall;
@@ -589,6 +569,15 @@ export const ActionBlock = memo(() => {
     if (isMarketClosed && !isPredictionMarket) {
       return ValidityCheckE.Closed;
     }
+    // slippage check 1 (sign of perp price)
+    let isInvalidPrice = false;
+    if (orderInfo.orderType === OrderTypeE.Market && perpetualPrice !== undefined) {
+      isInvalidPrice = perpetualPrice < 0;
+    }
+    if (isInvalidPrice) {
+      return ValidityCheckE.SlippageTooLarge;
+    }
+    // slippage check 2 (max/min price)
     if (
       orderInfo.orderType === OrderTypeE.Market &&
       orderInfo.maxMinEntryPrice !== null &&

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -123,7 +123,6 @@ const orderTypeMap: Record<OrderTypeE, string> = {
 enum ValidityCheckE {
   Empty = '-',
   Closed = 'closed',
-  OrderTooLarge = 'order-too-large',
   OrderTooSmall = 'order-too-small',
   PositionTooSmall = 'position-too-small',
   BelowMinPosition = 'below-min-position',
@@ -558,15 +557,6 @@ export const ActionBlock = memo(() => {
       !perpetualStaticInfo?.lotSizeBC
     ) {
       return ValidityCheckE.Empty;
-    }
-    let isTooLarge;
-    if (orderInfo.orderBlock === OrderBlockE.Long) {
-      isTooLarge = orderInfo.size > Math.abs(maxOrderSize.maxBuy);
-    } else {
-      isTooLarge = orderInfo.size > Math.abs(maxOrderSize.maxSell);
-    }
-    if (isTooLarge) {
-      return ValidityCheckE.OrderTooLarge;
     }
     const isOrderTooSmall = orderInfo.size > 0 && orderInfo.size < perpetualStaticInfo.lotSizeBC;
     if (isOrderTooSmall) {

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -123,6 +123,7 @@ const orderTypeMap: Record<OrderTypeE, string> = {
 enum ValidityCheckE {
   Empty = '-',
   Closed = 'closed',
+  OrderTooLarge = 'order-too-large',
   OrderTooSmall = 'order-too-small',
   PositionTooSmall = 'position-too-small',
   BelowMinPosition = 'below-min-position',
@@ -557,6 +558,15 @@ export const ActionBlock = memo(() => {
       !perpetualStaticInfo?.lotSizeBC
     ) {
       return ValidityCheckE.Empty;
+    }
+    let isTooLarge;
+    if (orderInfo.orderBlock === OrderBlockE.Long) {
+      isTooLarge = orderInfo.size > Math.abs(maxOrderSize.maxBuy);
+    } else {
+      isTooLarge = orderInfo.size > Math.abs(maxOrderSize.maxSell);
+    }
+    if (isTooLarge) {
+      return ValidityCheckE.OrderTooLarge;
     }
     const isOrderTooSmall = orderInfo.size > 0 && orderInfo.size < perpetualStaticInfo.lotSizeBC;
     if (isOrderTooSmall) {

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -232,7 +232,7 @@ export const ActionBlock = memo(() => {
             maxShort = 0;
           }
         }
-        if (data.data.ammPrice <= 0) {
+        if (orderInfo.orderType === OrderTypeE.Market && data.data.ammPrice <= 0) {
           if (orderInfo.orderBlock === OrderBlockE.Long) {
             maxLong = 0;
           } else {

--- a/src/components/order-block/elements/action-block/ActionBlock.tsx
+++ b/src/components/order-block/elements/action-block/ActionBlock.tsx
@@ -234,9 +234,9 @@ export const ActionBlock = memo(() => {
         }
         if (orderInfo.orderType === OrderTypeE.Market && data.data.ammPrice <= 0) {
           if (orderInfo.orderBlock === OrderBlockE.Long) {
-            maxLong = 0;
+            maxLong = maxLong * 0.75;
           } else {
-            maxShort = 0;
+            maxShort = maxShort * 0.75;
           }
         }
         setMaxOrderSize({ maxBuy: maxLong, maxSell: maxShort });

--- a/src/components/order-block/elements/slippage-selector/SlippageSelector.tsx
+++ b/src/components/order-block/elements/slippage-selector/SlippageSelector.tsx
@@ -10,7 +10,7 @@ import { OrderTypeE } from 'types/enums';
 import styles from './SlippageSelector.module.scss';
 
 const MIN_SLIPPAGE = 0.01;
-const MAX_SLIPPAGE = 100;
+const MAX_SLIPPAGE = 100000;
 const MULTIPLIERS = [1, 2, 3, 5];
 
 export const SlippageSelector = memo(() => {

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -136,6 +136,7 @@ export function positionRiskOnTrade(
     orderCost: number;
     maxLongTrade: number;
     maxShortTrade: number;
+    ammPrice: number;
   }>
 > {
   return traderAPI
@@ -146,6 +147,7 @@ export function positionRiskOnTrade(
         orderCost: number;
         maxLongTrade: number;
         maxShortTrade: number;
+        ammPrice: number;
       }>;
     });
 }

--- a/src/pages/trader-page/components/table-data-refetcher/TableDataFetcher.tsx
+++ b/src/pages/trader-page/components/table-data-refetcher/TableDataFetcher.tsx
@@ -9,9 +9,11 @@ import { ToastContent } from 'components/toast-content/ToastContent';
 import { getOpenOrders, getPositionRisk } from 'network/network';
 import { latestOrderSentTimestampAtom } from 'store/order-block.store';
 import {
+  cancelOrderIdAtom,
   clearOpenOrdersAtom,
   clearPositionsAtom,
   executeOrderAtom,
+  failOrderIdAtom,
   fundingListAtom,
   openOrdersAtom,
   positionsAtom,
@@ -34,8 +36,10 @@ export const TableDataFetcher = memo(() => {
 
   const latestOrderSentTimestamp = useAtomValue(latestOrderSentTimestampAtom);
   const traderAPI = useAtomValue(traderAPIAtom);
+  const cancelledOrderIds = useAtomValue(cancelOrderIdAtom);
   const [openOrders, setOpenOrders] = useAtom(openOrdersAtom);
   const [executedOrders, setOrderExecuted] = useAtom(executeOrderAtom);
+  const [failedOrderIds, setOrderFailed] = useAtom(failOrderIdAtom);
   const setTriggerBalancesUpdate = useSetAtom(triggerBalancesUpdateAtom);
   const clearOpenOrders = useSetAtom(clearOpenOrdersAtom);
   const clearPositions = useSetAtom(clearPositionsAtom);
@@ -108,9 +112,13 @@ export const TableDataFetcher = memo(() => {
                 ]}
               />
             );
-          } else if (!executedOrders.has(order.id)) {
-            setOrderExecuted(order.id);
-            toast.success(
+          } else if (
+            !executedOrders.has(order.id) &&
+            !cancelledOrderIds.has(order.id) &&
+            !failedOrderIds.has(order.id)
+          ) {
+            setOrderFailed(order.id);
+            toast.error(
               <ToastContent
                 title={t('pages.trade.positions-table.toasts.trade-failed.title')}
                 bodyLines={[
@@ -129,7 +137,7 @@ export const TableDataFetcher = memo(() => {
         }
       }
     },
-    [executedOrders, t, openOrders, traderAPI, setOrderExecuted]
+    [executedOrders, failedOrderIds, cancelledOrderIds, t, openOrders, traderAPI, setOrderExecuted, setOrderFailed]
   );
 
   useEffect(() => {

--- a/src/store/pools.store.ts
+++ b/src/store/pools.store.ts
@@ -254,6 +254,20 @@ export const failOrderIdAtom = atom(
   }
 );
 
+const cancelledOrderIdsAtom = atom<Set<string>>(new Set<string>());
+
+export const cancelOrderIdAtom = atom(
+  (get) => {
+    return get(cancelledOrderIdsAtom);
+  },
+  (_get, set, orderId: string) => {
+    set(cancelledOrderIdsAtom, (prev) => {
+      prev.add(orderId);
+      return prev;
+    });
+  }
+);
+
 const collateralToSettleConversionsAtom = atom<Map<string, CollToSettleInfoI>>(new Map());
 
 export const collateralToSettleConversionAtom = atom(


### PR DESCRIPTION
- atom with order ids being cancelled
- if user cancels an order, the id is registered
- if: 
    - order id disappears from open orders, 
    - it wasn't executed nor cancelled by the user, 
    - it wasn't registered as failed via websocket, 
   then we show a trade failed toast